### PR TITLE
feat: application-design DETAIL 게이트에 리뷰 옵션 추가

### DIFF
--- a/skills/aidlc-application-design/SKILL.md
+++ b/skills/aidlc-application-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aidlc-application-design
-description: Designs component and service structure before implementation. Conditional Construction stage. Called by inception-orchestrator.
+description: Use when component and service structure needs to be designed before implementation, as a conditional INCEPTION stage after workflow-planning.
 metadata:
   version: 0.6.0
   author: Jay

--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -248,13 +248,26 @@ B) [depth에 따라 조건부 표시]
    - Standard/Comprehensive: 승인, 상세 설계 진행 → application-design: DETAIL 호출
 ```
 
-#### 8b. DETAIL 게이트 [표준 게이트] (Standard/Comprehensive만)
+#### 8b. DETAIL 게이트 [리뷰 연계 게이트] (Standard/Comprehensive만)
 
 ```
 [application-design DETAIL 결과 표시]
 A) 변경 요청 → application-design: DETAIL 재호출
 B) 승인, INCEPTION 완료
+R) 리뷰 요청 → artifact-reviewer dispatch 후 결과와 함께 게이트 재표시
 ```
+
+**R 선택 시 리뷰 프로세스:**
+1. `_shared/reviewers/artifact-reviewer-prompt.md`를 서브에이전트로 dispatch
+   - 리뷰 대상: `devflow-docs/inception/application-design.md`
+   - 참조 컨텍스트: `requirements.md`, `nfr-requirements.md` (있으면), `workspace.md`
+2. 리뷰 결과를 게이트에 포함하여 재표시:
+   ```
+   [리뷰 결과 표시]
+   A) 리뷰 반영하여 수정 → application-design: DETAIL 재호출
+   B) 리뷰 참고, 현재 상태로 승인 → INCEPTION 완료
+   ```
+3. conventions 리뷰 루프 규약 적용 (Issues → 수정 권장, Recommendations → 참고)
 
 **DETAIL 호출 시 NFR Design 활성화 판단:**
 3가지 조건 모두 충족 시 인라인 신호 추가:


### PR DESCRIPTION
## Summary
- inception-orchestrator 게이트 #8b에 `R) 리뷰 요청` 옵션 추가
- 기존 `artifact-reviewer-prompt.md`를 활용 (신규 리뷰어 없음)
- 리뷰 결과와 함께 게이트 재표시 → 사용자가 반영/무시 결정
- 향후 외부 AI (Codex 등) 통합 시 리뷰어만 교체하면 되는 구조
- application-design H2 정합성: description CSO 수정

## 변경 파일
| 파일 | 작업 |
|------|------|
| `aidlc-inception-orchestrator/SKILL.md` | 게이트 #8b에 R 옵션 + 리뷰 프로세스 |
| `aidlc-application-design/SKILL.md` | H2 description CSO |

## Test plan
- [x] 게이트 #8b에 A/B/R 3가지 옵션이 명시되어 있는지 확인
- [x] R 선택 시 artifact-reviewer-prompt.md dispatch 프로세스가 명시되어 있는지 확인
- [x] 리뷰 대상 파일 경로와 참조 컨텍스트가 명시되어 있는지 확인
- [x] application-design description이 "Use when..."으로 시작하는지 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)