### PR TITLE
feat: finishing-branch 완료 후 devflow 종료 처리 (closes #26)

### DIFF
--- a/skills/_utils/devflow-state/SKILL.md
+++ b/skills/_utils/devflow-state/SKILL.md
@@ -30,7 +30,7 @@ When creating or updating the state file, maintain this exact structure:
 # devflow State
 
 ## Current Phase
-<!-- 현재 단계: inception | construction | operations | complete -->
+<!-- 현재 단계: inception | construction | operations | complete | finished -->
 [phase name]
 
 ## Current Stage

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -117,6 +117,11 @@ git worktree prune
 [워크트리 제거: [worktree-path]] (워크트리 사용 시)
 ```
 
+**devflow 종료 처리** (devflow-state.md가 존재하는 경우):
+1. `devflow-docs/devflow-state.md`의 `## Current Phase`를 `finished`로 업데이트
+2. `devflow-docs/devflow-state.md`를 `devflow-docs/devflow-state-archived-[timestamp].md`로 이름 변경
+3. devflow-audit에 로깅: `"Flow finished — option A (local merge)"`
+
 ---
 
 #### 옵션 B: Push 후 Pull Request 생성
@@ -157,9 +162,12 @@ EOF
 PR URL: [github-pr-url]
 리뷰어에게 공유하거나 직접 병합할 수 있습니다.
 워크트리는 PR 머지 전까지 유지됩니다.
+devflow는 PR 머지 후 종료 처리됩니다.
 ```
 
 **워크트리는 PR이 머지될 때까지 유지한다. 이 단계에서 제거하지 않는다.**
+
+**devflow state 유지**: 옵션 B에서는 devflow-state.md를 아카이브하지 않는다. PR 머지 후 다음 세션에서 using-devflow가 PR 머지 확인 → 종료 처리를 안내한다. devflow-state에 `## Finishing Choice`를 `B (PR pending)` + `## PR URL`을 `[github-pr-url]`로 기록한다.
 
 ---
 
@@ -231,16 +239,21 @@ git branch -D [branch-name]
 [삭제된 워크트리: [worktree-path]] (워크트리 사용 시)
 ```
 
+**devflow 종료 처리** (devflow-state.md가 존재하는 경우):
+1. `devflow-docs/devflow-state.md`의 `## Current Phase`를 `finished`로 업데이트
+2. `devflow-docs/devflow-state.md`를 `devflow-docs/devflow-state-archived-[timestamp].md`로 이름 변경
+3. devflow-audit에 로깅: `"Flow finished — option D (discarded)"`
+
 ---
 
 ## 워크트리 정리 규칙 요약
 
-| 옵션 | 워크트리 처리 |
-|------|------------|
-| A (로컬 병합) | 워크트리 제거 (`git worktree remove`) |
-| B (PR 생성) | 워크트리 유지 (PR 머지 후 처리) |
-| C (브랜치 유지) | 워크트리 유지 |
-| D (폐기) | 워크트리 강제 제거 (`--force`) |
+| 옵션 | 워크트리 처리 | devflow 처리 |
+|------|------------|------------|
+| A (로컬 병합) | 워크트리 제거 (`git worktree remove`) | `finished` + 아카이브 |
+| B (PR 생성) | 워크트리 유지 (PR 머지 후 처리) | state 유지 (PR 머지 후 종료) |
+| C (브랜치 유지) | 워크트리 유지 | state 유지 |
+| D (폐기) | 워크트리 강제 제거 (`--force`) | `finished` + 아카이브 |
 
 ---
 

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -66,26 +66,88 @@ metadata:
 
 1. `devflow-docs/devflow-state.md` 읽기
 2. `devflow-docs/session-summary.md` 읽기 (있으면)
-3. 재개 게이트 제시:
-   ```
-   ## aidlc — 진행 중인 작업 발견
+3. `## Current Phase` 값에 따라 분기:
 
-   현재 단계: [Current Phase] > [Current Stage]
-   완료된 스테이지: [list]
-   마지막 완료: [session-summary의 최근 완료 항목] (있으면)
+#### Phase가 `finished`인 경우
 
-   A) 이전 작업 재개
-   B) 새 작업 시작 (기존 상태 초기화)
-   ```
-4. A 선택 시:
-   - devflow-audit에 로깅: `"Session resumed at [stage] — commit: [git rev-parse --short HEAD]"`
-   - `## Current Phase` 확인하여 해당 Phase Orchestrator 호출:
-     - `INCEPTION` → `aidlc-inception-orchestrator` 호출
-     - `CONSTRUCTION` → `aidlc-construction-orchestrator` 호출
-5. B 선택 시:
-   - 기존 state를 `devflow-state-archived-[timestamp].md`로 이름 변경
-   - 기존 session-summary를 `session-summary-archived-[timestamp].md`로 이름 변경 (있으면)
-   - New Flow 진행
+이전 플로우가 완전히 종료된 상태. 아카이브 처리가 누락된 경우.
+
+```
+## aidlc — 이전 플로우 완료됨
+
+이전 작업이 완료된 상태입니다.
+
+→ 새 작업을 시작합니다.
+```
+
+state를 `devflow-state-archived-[timestamp].md`로 이름 변경 후 New Flow 진행.
+
+#### Phase가 `complete`이고 `## Finishing Choice`가 `B (PR pending)`인 경우
+
+PR 생성 후 머지 대기 중인 상태.
+
+```
+## aidlc — PR 머지 대기 중
+
+이전 작업의 PR이 아직 열려있습니다.
+PR URL: [## PR URL 값]
+
+A) PR 머지 완료 → devflow 종료 처리
+B) PR 아직 진행 중 → 다른 작업 시작
+C) PR 확인 후 결정
+```
+
+A 선택 시:
+- `gh pr view [PR URL] --json state`로 머지 확인 (가능한 경우)
+- devflow-state의 `## Current Phase`를 `finished`로 업데이트
+- state를 `devflow-state-archived-[timestamp].md`로 이름 변경
+- 워크트리 존재 시 제거 (`git worktree remove` + `git worktree prune`)
+- devflow-audit에 로깅: `"Flow finished — PR merged"`
+- 새 작업 시작 여부 안내
+
+B 선택 시:
+- state를 `devflow-state-archived-[timestamp].md`로 이름 변경
+- New Flow 진행
+
+C 선택 시:
+- PR 상태를 `gh pr view`로 확인 후 결과에 따라 A 또는 재안내
+
+#### Phase가 `complete`인 경우 (Finishing Choice 없음)
+
+CONSTRUCTION은 완료됐지만 finishing-branch를 아직 실행하지 않은 상태.
+
+```
+## aidlc — CONSTRUCTION 완료, 브랜치 처리 대기
+
+INCEPTION + CONSTRUCTION이 완료되었습니다.
+
+A) aidlc-finishing-a-development-branch 실행 → 브랜치 처리
+B) 새 작업 시작 (기존 상태 초기화)
+```
+
+#### Phase가 `INCEPTION` 또는 `CONSTRUCTION`인 경우 (기존 동작)
+
+```
+## aidlc — 진행 중인 작업 발견
+
+현재 단계: [Current Phase] > [Current Stage]
+완료된 스테이지: [list]
+마지막 완료: [session-summary의 최근 완료 항목] (있으면)
+
+A) 이전 작업 재개
+B) 새 작업 시작 (기존 상태 초기화)
+```
+
+A 선택 시:
+- devflow-audit에 로깅: `"Session resumed at [stage] — commit: [git rev-parse --short HEAD]"`
+- `## Current Phase` 확인하여 해당 Phase Orchestrator 호출:
+  - `INCEPTION` → `aidlc-inception-orchestrator` 호출
+  - `CONSTRUCTION` → `aidlc-construction-orchestrator` 호출
+
+B 선택 시:
+- 기존 state를 `devflow-state-archived-[timestamp].md`로 이름 변경
+- 기존 session-summary를 `session-summary-archived-[timestamp].md`로 이름 변경 (있으면)
+- New Flow 진행
 
 ## Phase 전환
 


### PR DESCRIPTION
## Summary
- devflow-state phase 값에 `finished` 추가
- finishing-branch 옵션 A/D 완료 시 state를 `finished`로 업데이트 + 아카이브
- 옵션 B(PR 생성)는 state 유지 — PR 머지 후 다음 세션에서 종료 처리
- using-devflow Resume Flow에 `finished`/`complete`(PR 대기)/`complete`(finishing 미실행) 분기 추가

## 변경 파일
- `skills/_utils/devflow-state/SKILL.md` — phase에 `finished` 추가
- `skills/aidlc-finishing-a-development-branch/SKILL.md` — 옵션별 devflow 종료 처리 + 요약 테이블 업데이트
- `skills/aidlc-using-devflow/SKILL.md` — Resume Flow 4가지 분기 처리

## Test plan
- [x] `tests/validate-skills.sh` 구조 검증 통과 (에러 0건)
- [x] 실제 devflow 플로우에서 옵션 A 선택 후 다음 세션 재개 시 "이전 플로우 완료됨" 표시 확인
- [x] 옵션 B 선택 후 PR 머지 대기 상태에서 재개 시 PR 머지 확인 게이트 표시 확인

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)