### PR TITLE
chore: skill-reviewer invoke_mode별 필수 섹션 규칙 추가 (closes #48)

### DIFF
--- a/skills/_shared/reviewers/skill-reviewer-prompt.md
+++ b/skills/_shared/reviewers/skill-reviewer-prompt.md
@@ -26,7 +26,15 @@ Agent tool (general-purpose):
     | description 시작 | "Use when..."으로 시작하는가 |
     | description 내용 | 워크플로우 요약이 포함되어 있지 않은가 (트리거 조건만 기술) |
     | description 길이 | 1024자 이하인가 |
-    | 필수 섹션 | Trigger, Examples (2개 이상), Troubleshooting (2개 이상) 존재하는가 |
+    | 필수 섹션 | invoke_mode별 기준 적용 (아래 표 참조) |
+
+    **invoke_mode별 필수 섹션:**
+
+    | 섹션 | user-invocable | orchestrator-only |
+    |------|---------------|-------------------|
+    | Trigger | 필수 | 선택 |
+    | Examples (2개+) | 필수 | 선택 |
+    | Troubleshooting / Common Issues / Error Handling (2개+) | 필수 | 필수 |
     | 줄 수 | 500줄 이하인가 (초과 시 분리 권고) |
 
     ## 2. 내용 검증 (skill-writing-guide.md 기준)


### PR DESCRIPTION
Closes #48

## Summary
- skill-reviewer에 `invoke_mode`별 필수 섹션 기준 추가
- orchestrator-only 스킬은 Trigger/Examples 선택, Troubleshooting 필수
- Troubleshooting/Common Issues/Error Handling을 동의어로 허용
- S5(#51), S6(#52)는 실제 문제 증거 없이 과잉 투자로 판단하여 not_planned 클로즈

## 변경 내역

| invoke_mode | Trigger | Examples | Troubleshooting류 |
|-------------|---------|----------|-------------------|
| user-invocable | 필수 | 필수 (2개+) | 필수 (2개+) |
| orchestrator-only | 선택 | 선택 | 필수 (2개+) |

## S5/S6 클로즈 근거
- 25/27 스킬이 Trigger/Examples 없이도 정상 동작 중
- 한국어 키워드 없이도 미트리거 사례 없음
- 일괄 보강은 실익 대비 볼륨 과다 → 실제 문제 발생 시 개별 대응

## Test plan
- [x] `bash tests/run-all.sh` — 95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)