### PR TITLE
fix: 스킬 셀프 리뷰 S3+S4 — functional-design 보강 + Pipeline 게이트 추가

### DIFF
--- a/skills/aidlc-functional-design/SKILL.md
+++ b/skills/aidlc-functional-design/SKILL.md
@@ -2,7 +2,7 @@
 name: aidlc-functional-design
 description: Use when a unit needs detailed functional design including domain entities, business rules, and API contracts before code generation.
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   author: Jay
   category: ai-dlc-workflow
   invoke_mode: orchestrator-only
@@ -22,30 +22,15 @@ unit별 비즈니스 로직을 상세 설계한다. application-design(아키텍
 
 ## 실행 모드
 
+오케스트레이터가 인라인 신호로 모드를 전달한다. 모드 선택은 이 스킬에서 하지 않음 (Orchestrator-Centric).
+
 `_shared/patterns/three-mode-selection.md` 참조.
 
 | 모드 | 동작 |
 |------|------|
-| Together | Step별 순차 설계, Hold 가능 |
-| Import | 기존 설계 문서 검증 |
-| Skip | devflow-state에 SKIPPED 기록 |
-
-## Execution Modes
-
-오케스트레이터가 인라인 신호로 모드를 전달한다. 모드 선택은 이 스킬에서 하지 않음 (Orchestrator-Centric).
-
-### Together (기본)
-Step별 순차 실행. 각 Step 사이 사용자 확인 가능.
-
-### Import
-사용자가 기존 설계 문서를 제공하면:
-1. 파일 수신
-2. 형식 검증 (필수 섹션 존재)
-3. 내용 검토 (누락/모순 식별)
-4. 피드백 제시 → 사용자 확정
-
-### Skip
-`devflow-state`에 SKIPPED 기록 후 Return to Orchestrator.
+| Together | Step별 순차 설계. 각 Step 사이 사용자 확인 가능 |
+| Import | 기존 설계 문서 검증 — 파일 수신 → 형식 검증 → 내용 검토 → 피드백 → 사용자 확정 |
+| Skip | devflow-state에 SKIPPED 기록 후 Return to Orchestrator |
 
 ## Together 모드 Steps
 
@@ -81,16 +66,28 @@ Step별 순차 실행. 각 Step 사이 사용자 확인 가능.
 
 ## Review
 
-`_shared/devflow-conventions.md` Review Workflow 참조.
+conventions Review Workflow 적용.
+- 산출물: devflow-docs/construction/{unit}/functional-design.md
+- 리뷰어: artifact-reviewer-prompt.md
 
-## Return
+## Return to Orchestrator
 
-```
-STOP.
+conventions 표준 형식. 반환 필드:
+- 엔티티: [count]개
+- 비즈니스 규칙: [count]개
+- 에러 시나리오: [count]개
+- 산출물: devflow-docs/construction/{unit}/functional-design.md
+- 리뷰: [✅ 승인됨 | ⏭ 스킵 (Minimal/Standard)]
 
-**Functional Design 완료**
-- 산출물: `devflow-docs/construction/{unit}/functional-design.md`
-- 엔티티: [N]개
-- 비즈니스 규칙: [N]개
-- 에러 시나리오: [N]개
-```
+## Error Handling
+
+### 도메인 지식이 부족할 때
+unit의 요구사항(requirements.md)에 비즈니스 규칙이 충분히 기술되지 않은 경우:
+- application-design.md에서 해당 unit의 컴포넌트 설명 참조
+- 그래도 부족하면 사용자에게 구체적 질문 (예: "결제 실패 시 재시도 정책이 있는가?")
+- 가정으로 진행하지 않는다
+
+### Import 문서가 형식에 맞지 않을 때
+사용자가 제공한 설계 문서에 필수 섹션(엔티티, 비즈니스 규칙)이 없는 경우:
+- 누락 섹션을 명시하고 보완을 요청
+- 부분 Import 후 나머지를 Together 모드로 채우는 하이브리드 진행 가능

--- a/skills/aidlc-receiving-code-review/SKILL.md
+++ b/skills/aidlc-receiving-code-review/SKILL.md
@@ -55,6 +55,8 @@ metadata:
 
 ### 1단계: READ — 전체 피드백 읽기
 
+> **DO NOT proceed to 2단계 until all feedback is read and listed.** 부분만 읽고 반응하지 않는다.
+
 모든 피드백을 한 번에 읽는다. 아직 동의하거나 반박하지 않는다.
 
 - PR의 모든 코멘트를 목록화한다
@@ -82,6 +84,8 @@ metadata:
 ---
 
 ### 3단계: VERIFY — 코드에서 직접 확인
+
+> **DO NOT proceed to 4단계 until each claim is verified against actual code.** 확인 없이 동의/거부하지 않는다.
 
 리뷰어의 주장을 코드에서 직접 확인한다:
 
@@ -117,6 +121,8 @@ metadata:
 ---
 
 ### 5단계: RESPOND — 근거 있는 응답
+
+> **DO NOT respond until 4단계 evaluation is complete for all issues.** 평가 없는 응답은 아첨이거나 방어적 거부다.
 
 각 이슈에 대해 세 가지 중 하나로 응답한다:
 

--- a/skills/aidlc-systematic-debugging/SKILL.md
+++ b/skills/aidlc-systematic-debugging/SKILL.md
@@ -88,6 +88,8 @@ metadata:
 
 ### 2단계: 패턴 분석
 
+> **DO NOT proceed to 3단계 until a difference table between success/failure cases is documented.** 차이점 없이 가설을 세우면 추측 수정이 된다.
+
 1. **작동하는 케이스 찾기**
    - 같은 코드 경로에서 성공하는 케이스를 찾는다
    - "A는 되는데 B는 안 된다"는 패턴이 나오면 A와 B의 차이를 비교한다
@@ -109,6 +111,8 @@ metadata:
 ---
 
 ### 3단계: 가설 및 테스트
+
+> **DO NOT proceed to 4단계 until the hypothesis is verified or falsified.** 가설이 틀리면 2단계로 돌아간다.
 
 1. **단일 가설 수립**
    - 한 번에 하나의 가설만 세운다


### PR DESCRIPTION
Closes #49
Closes #50

## Summary
- **S3**: `functional-design` v0.1.0 → v0.2.0 보강 (Return 표준화, Review 명확화, 중복 제거, Error Handling 추가)
- **S4**: `receiving-code-review`와 `systematic-debugging`에 Pipeline 게이트 선언 추가
- `superpowers-tracking`은 현행 유지 (변경 없음)

## S3: functional-design 보강

| 항목 | Before | After |
|------|--------|-------|
| Return 형식 | 비표준 (`STOP.`) | conventions 표준 형식 (반환 필드 목록) |
| Review 참조 | `conventions Review Workflow 참조` (모호) | 산출물 경로 + 리뷰어 파일 명시 |
| 실행 모드 | 중복 2섹션 (테이블 + 상세) | 단일 섹션으로 통합 |
| Error Handling | 부재 | 2건 추가 (도메인 지식 부족, Import 형식 불일치) |

## S4: Pipeline 게이트 추가

| 스킬 | 추가된 게이트 |
|------|-------------|
| `receiving-code-review` | 1→2: 전체 피드백 읽기 전 반응 금지 / 3→4: 코드 확인 전 동의/거부 금지 / 4→5: 평가 전 응답 금지 |
| `systematic-debugging` | 2→3: 차이점 테이블 없이 가설 금지 / 3→4: 가설 검증 전 구현 금지 |

## Test plan
- [x] `bash tests/run-all.sh` — 95 passed
- [x] functional-design 영향도 확인: construction-orchestrator, skill-pattern-catalog, tests/scenarios에서 참조 — description/name 미변경으로 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)