### PR TITLE
feat: Agent Teams 기반 협업 코드 리뷰 R3 모드 추가 (refs #69)

### DIFF
--- a/agents/maintainability-reviewer.md
+++ b/agents/maintainability-reviewer.md
@@ -1,0 +1,49 @@
+# Maintainability & Future Risk Reviewer Agent
+
+## 역할
+
+유지보수성 리뷰어. Agent Teams 팀원으로 참여하여 장기 유지보수성과 미래 변경 리스크를 평가한다.
+기존 `_shared/reviewers/maintainability-reviewer-prompt.md`의 검증 기준을 따른다.
+
+## 검토 기준
+
+1. 결합도: 불필요한 직접 의존, 변경 전파 리스크, 순환 의존
+2. 가독성: 의도 명확성, 매직 넘버, 함수 길이, 네이밍 일관성
+3. 확장성: 새 케이스 추가 시 수정 범위, Open/Closed 원칙
+4. 테스트 유지보수성: 구현 세부사항 과결합, 리팩토링 시 깨지는 구조
+5. 기술 부채 징후: TODO/FIXME, deprecated API, 복사-붙여넣기 코드
+
+> 상세 기준: `_shared/reviewers/maintainability-reviewer-prompt.md` 참조
+
+## 팀 소통 프로토콜
+
+### 리뷰 완료 후
+1. 팀 리드에게 결과 보고 (SendMessage)
+2. 결합도/확장성 이슈가 아키텍처와 관련되면 quality-reviewer에게 DM
+3. 기술 부채가 보안 위험으로 이어질 수 있으면 security-reviewer에게 DM
+
+### 다른 리뷰어로부터 메시지 수신 시
+- quality-reviewer의 아키텍처 이슈는 자신의 결합도/확장성 분석에 반영
+- 범위 밖이면 수신 확인만
+
+## 출력 형식
+
+```
+## Maintainability & Future Risk Review
+
+**Status:** Maintainable | Issues Found
+
+### Change Impact Summary
+[유지보수 영향 요약]
+
+### Issues
+**Critical:** [있으면 — file:line, 리스크, 영향 범위, 수정 방안]
+**Important:** [있으면]
+**Minor:** [있으면]
+
+### Tech Debt Indicators
+- [발견된 기술 부채 징후]
+
+### Cross-cutting Notes
+[다른 리뷰어에게 공유할 발견 사항]
+```

--- a/agents/quality-reviewer.md
+++ b/agents/quality-reviewer.md
@@ -1,0 +1,46 @@
+# Code Quality Reviewer Agent
+
+## 역할
+
+코드 품질 리뷰어. Agent Teams 팀원으로 참여하여 코드 품질, 테스트 품질, 아키텍처 적합성을 검증한다.
+기존 `_shared/reviewers/code-quality-reviewer-prompt.md`의 검증 기준을 따른다.
+
+## 검토 기준
+
+1. 코드 품질: 가독성, 네이밍, 구조
+2. 테스트 품질: 커버리지, 경계 케이스, 테스트 격리
+3. 아키텍처: 기존 패턴 준수, 적절한 추상화 수준
+4. 에러 핸들링: 적절한 에러 처리, 실패 경로의 명확성
+5. DRY: 불필요한 중복 없음
+6. 기본 보안 체크 (명백한 취약점만)
+
+> 상세 기준: `_shared/reviewers/code-quality-reviewer-prompt.md` 참조
+
+## 팀 소통 프로토콜
+
+### 리뷰 완료 후
+1. 팀 리드에게 결과 보고 (SendMessage)
+2. 품질 이슈가 보안에도 영향을 미칠 수 있으면 security-reviewer에게 DM
+3. 아키텍처 이슈가 유지보수성에도 영향을 미치면 maintainability-reviewer에게 DM
+4. spec-reviewer의 누락 보고와 겹치는 코드 품질 이슈가 있으면 조율
+
+### 다른 리뷰어로부터 메시지 수신 시
+- 자신의 리뷰 범위와 관련된 정보면 반영하여 결과 보완
+- 범위 밖이면 수신 확인만
+
+## 출력 형식
+
+```
+## Code Quality Review
+
+**Assessment:** Approved | Requires Changes
+**Strengths:** [잘된 점]
+
+### Issues
+**Critical:** [있으면]
+**Important:** [있으면]
+**Minor:** [있으면]
+
+### Cross-cutting Notes
+[다른 리뷰어에게 공유할 발견 사항]
+```

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,0 +1,48 @@
+# Security & Edge-case Reviewer Agent
+
+## 역할
+
+보안/엣지케이스 리뷰어. Agent Teams 팀원으로 참여하여 보안 취약점과 엣지케이스를 심층 분석한다.
+기존 `_shared/reviewers/security-reviewer-prompt.md`의 검증 기준을 따른다.
+
+## 검토 기준
+
+1. OWASP Top 10 심층 분석 (Injection, 인증/인가, 민감 데이터 노출 등)
+2. 언어별 보안 주의사항
+3. 논리 오류 (조건문 누락, 경계값, Race condition)
+4. 엣지케이스 (빈 입력, 대량 데이터, 동시 요청, 유니코드)
+5. 데이터 흐름 분석 (신뢰 경계를 넘는 데이터 검증)
+
+> 상세 기준: `_shared/reviewers/security-reviewer-prompt.md` 참조
+
+## 팀 소통 프로토콜
+
+### 리뷰 완료 후
+1. 팀 리드에게 결과 보고 (SendMessage)
+2. 보안 이슈가 코드 품질과 관련되면 quality-reviewer에게 DM (예: 입력 검증 누락)
+3. 보안 이슈가 spec 누락에서 기인하면 spec-reviewer에게 DM
+4. Critical 보안 이슈 발견 시 팀 리드에게 즉시 알림 (다른 리뷰어 완료 대기 불필요)
+
+### 다른 리뷰어로부터 메시지 수신 시
+- quality-reviewer가 "기본 보안 체크"에서 발견한 항목은 자신의 심층 분석에 반영
+- 범위 밖이면 수신 확인만
+
+## 출력 형식
+
+```
+## Security & Edge-case Review
+
+**Status:** Secure | Issues Found
+**Threat Surface:** [주요 위협 영역 요약]
+
+### Issues
+**Critical:** [있으면 — file:line, 공격 벡터, 영향, 수정 방안]
+**Important:** [있으면]
+**Minor:** [있으면]
+
+### Edge Cases Checked
+- [검증한 엣지케이스 목록과 결과]
+
+### Cross-cutting Notes
+[다른 리뷰어에게 공유할 발견 사항]
+```

--- a/agents/spec-reviewer.md
+++ b/agents/spec-reviewer.md
@@ -1,0 +1,39 @@
+# Spec Compliance Reviewer Agent
+
+## 역할
+
+Spec compliance 리뷰어. Agent Teams 팀원으로 참여하여 구현이 요구사항을 정확히 충족하는지 검증한다.
+기존 `_shared/reviewers/spec-reviewer-prompt.md`의 검증 기준을 따른다.
+
+## 검토 기준
+
+1. 요청된 모든 요구사항이 구현되었는가 (누락 확인)
+2. 요청하지 않은 것이 추가되었는가 (과잉 구현 확인)
+3. 요구사항의 의도가 정확히 반영되었는가 (오해 확인)
+
+> 상세 기준: `_shared/reviewers/spec-reviewer-prompt.md` 참조
+
+## 팀 소통 프로토콜
+
+### 리뷰 완료 후
+1. 팀 리드에게 결과 보고 (SendMessage)
+2. 다른 리뷰어의 발견 사항과 겹치는 부분이 있으면 해당 리뷰어에게 DM으로 공유
+3. Spec 누락이 다른 관점(보안, 품질)에도 영향을 미칠 수 있으면 관련 리뷰어에게 알림
+
+### 다른 리뷰어로부터 메시지 수신 시
+- 자신의 리뷰 범위와 관련된 정보면 반영하여 결과 보완
+- 범위 밖이면 수신 확인만
+
+## 출력 형식
+
+```
+## Spec Compliance Review
+
+**Status:** Spec Compliant | Issues Found
+**Missing:** [누락된 요구사항]
+**Extra:** [과잉 구현]
+**Misunderstood:** [오해된 요구사항]
+
+### Cross-cutting Notes
+[다른 리뷰어에게 공유할 발견 사항]
+```

--- a/skills/_shared/patterns/review-team-protocol.md
+++ b/skills/_shared/patterns/review-team-protocol.md
@@ -1,0 +1,142 @@
+# Review Team Protocol — Agent Teams 협업 리뷰
+
+> requesting-code-review R3 모드에서 참조하는 프로토콜.
+> 리뷰어들이 Agent Teams로 협업하여 코드 리뷰를 수행하는 절차를 정의한다.
+
+## 팀 생성
+
+TeamCreate로 리뷰 팀을 생성한다:
+
+```
+TeamCreate:
+  team_name: "code-review-{unit-name}"
+  description: "Code review for {unit-name}"
+```
+
+## 리뷰어 Spawn
+
+depth에 따라 리뷰어를 Agent(Explore 타입)로 spawn한다.
+Explore 타입은 Read-only — 코드를 읽고 분석만 수행하며, 수정은 팀 리드가 담당한다.
+
+### Standard depth (3인 팀)
+
+| 리뷰어 | 에이전트 정의 | 리뷰 관점 |
+|--------|-------------|----------|
+| spec-reviewer | `agents/spec-reviewer.md` | Spec compliance (spec 제공 시만) |
+| quality-reviewer | `agents/quality-reviewer.md` | Code quality |
+| security-reviewer | `agents/security-reviewer.md` | Security/edge-case |
+
+spec 미제공 시 spec-reviewer 스킵 → 2인 팀.
+
+### Comprehensive depth (4인 팀)
+
+Standard + maintainability-reviewer 추가:
+
+| 리뷰어 | 에이전트 정의 | 리뷰 관점 |
+|--------|-------------|----------|
+| maintainability-reviewer | `agents/maintainability-reviewer.md` | Maintainability/future risk |
+
+### Spawn 방법
+
+각 리뷰어를 Agent tool로 spawn:
+
+```
+Agent:
+  subagent_type: Explore
+  team_name: "code-review-{unit-name}"
+  name: "{reviewer-name}"
+  prompt: |
+    당신은 {reviewer-role}입니다.
+    리뷰 대상: {review-target}
+    참조 컨텍스트: {context-files}
+
+    {agents/{reviewer-name}.md}의 검토 기준에 따라 리뷰를 수행하세요.
+    완료 후 팀 리드에게 결과를 SendMessage로 보고하세요.
+    다른 리뷰어의 발견 사항과 관련된 내용이 있으면 해당 리뷰어에게 DM하세요.
+```
+
+모든 리뷰어를 **동시에 spawn** (병렬 실행).
+
+## 소통 규칙
+
+### 독립 분석 우선 원칙
+각 리뷰어는 **자신의 독립 분석을 먼저 완료**한 후에만 다른 리뷰어에게 DM을 보낸다. 다른 리뷰어의 중간 결과에 의해 자신의 초기 판단이 편향되는 것을 방지한다.
+
+### 리뷰어 → 팀 리드
+- 리뷰 완료 시 결과를 SendMessage로 보고
+- Critical 이슈 발견 시 즉시 알림 (다른 리뷰어 완료 대기 불필요)
+
+### 리뷰어 → 리뷰어 (DM)
+- 자신의 발견이 다른 관점에도 영향을 미칠 때 해당 리뷰어에게 DM
+- 예: quality-reviewer가 입력 검증 누락 발견 → security-reviewer에게 DM
+- 예: spec-reviewer가 기능 누락 발견 → quality-reviewer에게 "이 기능 테스트도 없음" DM
+- DM은 선택적 — 관련성이 명확할 때만
+
+### 팀 리드 → 리뷰어
+- 추가 분석 요청 시 해당 리뷰어에게 SendMessage
+- 모든 리뷰어가 idle 상태이면 결과 종합 시작
+
+### Critical 이슈 fast-path
+- security-reviewer가 Critical 이슈를 즉시 보고한 경우, 팀 리드는 해당 이슈를 기록하되 다른 리뷰어 완료를 대기
+- 모든 리뷰어 완료 후 일괄 종합 (Critical이 있어도 다른 이슈를 놓치지 않기 위해)
+
+## 결과 종합
+
+팀 리드(메인 에이전트)가 모든 리뷰어의 결과를 수신한 후:
+
+1. **중복 제거**: 여러 리뷰어가 같은 이슈를 보고한 경우 하나로 병합
+   - 동일 file:line + 동일 설명 → 병합
+   - 동일 file:line + 다른 관점 → Cross-cutting으로 분류
+   - 다른 파일 + 동일 근본 원인 → "Related to: ..." 표기로 연결
+2. **크로스 커팅 이슈 강조**: 여러 리뷰어의 관점이 교차하는 이슈를 별도 섹션으로
+   - 크로스 커팅 기준: 복수 리뷰어가 동일 코드 위치를 다른 맥락에서 지적하거나, 한 관점(예: spec)의 이슈가 다른 관점(예: security)에도 영향을 미치는 경우
+3. **이슈 분류 통합**: Critical > Important > Minor 순으로 정렬
+4. **최종 판정**: 모든 리뷰어의 Assessment를 종합하여 최종 판정
+
+### 종합 결과 형식
+
+```
+## Agent Teams Code Review 결과
+
+### 팀 구성
+- [참여한 리뷰어 목록]
+
+### 종합 판정
+**Assessment:** Ready to merge | Needs fixes
+**Critical Issues:** [N]건
+**Important Issues:** [N]건
+**Minor Issues:** [N]건
+
+### Cross-cutting Issues
+[리뷰어 간 소통에서 도출된 교차 관심사]
+
+### Issues by Reviewer
+#### Spec Compliance
+[spec-reviewer 결과]
+
+#### Code Quality
+[quality-reviewer 결과]
+
+#### Security/Edge-case
+[security-reviewer 결과]
+
+#### Maintainability (Comprehensive만)
+[maintainability-reviewer 결과]
+
+### Recommendations
+[수정 권장 사항]
+```
+
+## 팀 정리
+
+결과 종합 완료 후:
+
+1. 각 리뷰어에게 shutdown 요청: `SendMessage: {type: "shutdown_request"}`
+2. 모든 리뷰어 shutdown 확인
+3. `TeamDelete`로 팀 제거
+
+## Graceful Degradation
+
+Agent Teams 도구(TeamCreate/SendMessage)를 사용할 수 없는 환경에서는:
+- R3 선택 시 "Agent Teams를 사용할 수 없습니다. R1 (독립 서브에이전트)으로 전환합니다." 안내
+- 기존 R1 모드로 자동 fallback

--- a/skills/aidlc-requesting-code-review/SKILL.md
+++ b/skills/aidlc-requesting-code-review/SKILL.md
@@ -54,12 +54,15 @@ depth에 따라 3-stage (Standard) 또는 4-stage (Comprehensive) code review를
 리뷰 모드:
 R1) 단일 리뷰 (3-stage Standard / 4-stage Comprehensive) ← 기본
 R2) Council 리뷰
+R3) Agent Teams 협업 리뷰 (리뷰어 간 소통 기반)
 Ra) 자동 선택 (risk score 기반)
 ```
 
 **R1 선택**: Step 2 → Step 3 → Step 4 (기존 동작 그대로)
 
 **R2/Ra 선택**: Step 2c (Council 리뷰)로 진행
+
+**R3 선택**: Step 2t (Agent Teams 리뷰)로 진행
 
 ### Step 2: Stage 1 — Spec Compliance (R1 모드)
 
@@ -137,6 +140,41 @@ R2 또는 Ra 선택 시, 4-stage 관점을 외부 AI와 함께 실행한다.
    ```
 7. 결과를 Step 4 형식으로 반환 (council 모드 표시 추가)
 
+### Step 2t: Agent Teams 리뷰 (R3 모드)
+
+R3 선택 시, 리뷰어들이 Agent Teams로 팀을 구성하여 소통 기반 협업 리뷰를 수행한다.
+
+> **R1과 R3의 차이**: R1은 각 리뷰어가 독립 실행 후 결과만 수집. R3은 리뷰어 간 발견 사항을 공유하여 중복 제거, 크로스 커팅 이슈 발견이 가능하다.
+
+1. `_shared/patterns/review-team-protocol.md` 읽기
+2. **Stage 1 (Spec Compliance)**: spec/plan 제공 시 서브에이전트로 실행 (R1과 동일)
+   - 요구사항 대조는 사실 확인이므로 팀 협업 불필요
+3. **Stage 2-4를 Agent Teams로 실행**:
+   - TeamCreate → 리뷰 팀 생성
+   - depth에 따라 리뷰어 spawn (Explore 타입):
+     - Standard: quality-reviewer + security-reviewer (+ spec-reviewer if spec 제공)
+     - Comprehensive: + maintainability-reviewer
+   - 리뷰어들이 병렬로 리뷰 수행 + SendMessage로 발견 사항 공유
+   - 팀 리드가 모든 결과 수신 후 종합 (Step 4 형식으로 변환)
+   - TeamDelete로 팀 정리
+   - **이슈 수정 루프**: Needs fixes 판정 시 수정 후 팀 재생성하여 re-review (최대 5회, 초과 시 사용자 escalate — R1과 동일 제한)
+4. **종합 결과를 사용자에게 표시 + 승인 대기**:
+   ```
+   [Agent Teams Code Review 결과]
+   Assessment: [Ready to merge | Needs fixes]
+   Cross-cutting Issues: [리뷰어 간 소통에서 도출된 교차 이슈]
+   Issues: [분류별 목록]
+
+   A) 리뷰 반영하여 수정
+   B) 현재 상태로 승인
+   ```
+5. 결과를 Step 4 형식으로 반환 (teams 모드 표시 추가)
+
+**에러 핸들링**:
+- TeamCreate 실패 → "Agent Teams를 사용할 수 없습니다. R1으로 전환합니다." 안내 후 R1 흐름으로 자동 전환
+- Agent spawn 실패 (일부 리뷰어) → 성공한 리뷰어 결과만 종합 + 실패한 관점은 "⏭ 스킵 (spawn 실패)" 표시
+- 전체 Agent spawn 실패 → R1 fallback
+
 ### Step 4: 결과 반환
 
 ```
@@ -154,12 +192,12 @@ R2 또는 Ra 선택 시, 4-stage 관점을 외부 AI와 함께 실행한다.
 
 ## Standalone vs SDD 호출
 
-| 모드 | 트리거 | spec/plan | depth |
-|------|--------|-----------|-------|
-| **Standalone** | 사용자 직접 호출 | 사용자 지정 (없으면 Stage 1 스킵) | 사용자 지정 또는 Standard |
-| **SDD** | 태스크 완료 후 자동 | 태스크의 spec/plan 경로 | plan Complexity 연동 |
+| 모드 | 트리거 | spec/plan | depth | 리뷰 모드 |
+|------|--------|-----------|-------|----------|
+| **Standalone** | 사용자 직접 호출 | 사용자 지정 (없으면 Stage 1 스킵) | 사용자 지정 또는 Standard | 사용자 선택 (R1/R2/R3/Ra) |
+| **SDD** | 태스크 완료 후 자동 | 태스크의 spec/plan 경로 | plan Complexity 연동 | R1 (기본값 고정) |
 
-SDD에서 호출 시, SDD가 리뷰 대상(변경 파일)과 spec/plan 경로를 전달한다.
+SDD에서 호출 시, SDD가 리뷰 대상(변경 파일)과 spec/plan 경로를 전달한다. 리뷰 모드는 항상 R1 — 팀/Council 모드는 사용자 명시 선택 시에만.
 
 ---
 
@@ -228,6 +266,25 @@ SDD: 태스크 3 완료, requesting-code-review 호출
   → maintainability-reviewer → ✅ Maintainable
 → 수정 후 Stage 3 재리뷰 → ✅ Secure
 → 결과: Ready to merge / Recommendations 1건
+```
+
+### Example 4: Agent Teams 협업 리뷰 (Standard)
+
+```
+사용자: "팀 리뷰로 해줘" (R3 선택)
+
+[depth: Standard, spec 미제공]
+→ TeamCreate: "code-review-auth"
+→ Agent spawn (Explore):
+  - quality-reviewer: 코드 품질 분석 시작
+  - security-reviewer: 보안 분석 시작
+→ quality-reviewer → security-reviewer DM: "입력 검증 누락 발견 (auth.py:42)"
+→ security-reviewer: DM 반영하여 injection 경로 추가 분석
+→ 결과 종합:
+  - Cross-cutting: 입력 검증 누락이 품질+보안 모두에 영향
+  - Issues: Important 2건 (중복 제거됨, 원래 3건)
+→ TeamDelete
+→ 결과: Needs fixes / Important 2건
 ```
 
 ---

--- a/tests/test_agent_teams_review.py
+++ b/tests/test_agent_teams_review.py
@@ -1,0 +1,145 @@
+"""Tests for BL-043: Code Review Agent Teams.
+
+Validates agent files, review team protocol, and R3 mode integration.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+AGENTS_DIR = REPO_ROOT / "agents"
+SHARED_PATTERNS = REPO_ROOT / "skills" / "_shared" / "patterns"
+SKILL_DIR = REPO_ROOT / "skills" / "aidlc-requesting-code-review"
+
+REVIEWER_AGENTS = [
+    "spec-reviewer",
+    "quality-reviewer",
+    "security-reviewer",
+    "maintainability-reviewer",
+]
+
+REQUIRED_AGENT_SECTIONS = [
+    "## 역할",
+    "## 팀 소통 프로토콜",
+    "## 출력 형식",
+]
+
+
+class TestReviewerAgents:
+    """Step 1: 역할별 리뷰어 에이전트 파일 검증."""
+
+    @pytest.mark.parametrize("agent_name", REVIEWER_AGENTS)
+    def test_agent_file_exists(self, agent_name):
+        path = AGENTS_DIR / f"{agent_name}.md"
+        assert path.exists(), f"Agent file missing: {path}"
+
+    @pytest.mark.parametrize("agent_name", REVIEWER_AGENTS)
+    def test_agent_has_required_sections(self, agent_name):
+        path = AGENTS_DIR / f"{agent_name}.md"
+        if not path.exists():
+            pytest.skip(f"Agent file not yet created: {agent_name}")
+        content = path.read_text()
+        for section in REQUIRED_AGENT_SECTIONS:
+            assert section in content, (
+                f"{agent_name}.md missing section: {section}"
+            )
+
+    @pytest.mark.parametrize("agent_name", REVIEWER_AGENTS)
+    def test_agent_references_reviewer_prompt(self, agent_name):
+        """에이전트가 대응하는 _shared/reviewers/ 프롬프트를 참조하는지."""
+        path = AGENTS_DIR / f"{agent_name}.md"
+        if not path.exists():
+            pytest.skip(f"Agent file not yet created: {agent_name}")
+        content = path.read_text()
+        assert "_shared/reviewers/" in content, (
+            f"{agent_name}.md should reference its reviewer prompt"
+        )
+
+
+PROTOCOL_REQUIRED_SECTIONS = [
+    "## 팀 생성",
+    "## 리뷰어 Spawn",
+    "## 소통 규칙",
+    "## 결과 종합",
+    "## 팀 정리",
+]
+
+
+class TestReviewTeamProtocol:
+    """Step 2: review-team-protocol.md 검증."""
+
+    def test_protocol_file_exists(self):
+        path = SHARED_PATTERNS / "review-team-protocol.md"
+        assert path.exists(), f"Protocol file missing: {path}"
+
+    def test_protocol_has_required_sections(self):
+        path = SHARED_PATTERNS / "review-team-protocol.md"
+        if not path.exists():
+            pytest.skip("Protocol file not yet created")
+        content = path.read_text()
+        for section in PROTOCOL_REQUIRED_SECTIONS:
+            assert section in content, (
+                f"review-team-protocol.md missing section: {section}"
+            )
+
+    def test_protocol_references_team_tools(self):
+        """프로토콜이 TeamCreate, Agent, SendMessage, TeamDelete를 참조하는지."""
+        path = SHARED_PATTERNS / "review-team-protocol.md"
+        if not path.exists():
+            pytest.skip("Protocol file not yet created")
+        content = path.read_text()
+        for tool in ["TeamCreate", "SendMessage", "TeamDelete"]:
+            assert tool in content, (
+                f"review-team-protocol.md should reference {tool}"
+            )
+
+
+class TestR3ModeInSkill:
+    """Step 3: SKILL.md에 R3 모드 존재 검증."""
+
+    def test_skill_has_r3_option(self):
+        path = SKILL_DIR / "SKILL.md"
+        content = path.read_text()
+        assert "R3)" in content, "SKILL.md should define R3 option"
+
+    def test_skill_has_teams_review_step(self):
+        path = SKILL_DIR / "SKILL.md"
+        content = path.read_text()
+        assert "Agent Teams" in content, (
+            "SKILL.md should reference Agent Teams"
+        )
+
+    def test_skill_references_protocol(self):
+        path = SKILL_DIR / "SKILL.md"
+        content = path.read_text()
+        assert "review-team-protocol" in content, (
+            "SKILL.md should reference review-team-protocol.md"
+        )
+
+
+class TestR3Integration:
+    """Step 4: R3 모드 통합 검증."""
+
+    def test_r3_graceful_degradation_documented(self):
+        """프로토콜에 graceful degradation이 문서화되었는지."""
+        path = SHARED_PATTERNS / "review-team-protocol.md"
+        content = path.read_text()
+        assert "Graceful Degradation" in content
+
+    def test_all_reviewer_agents_referenced_in_protocol(self):
+        """프로토콜이 모든 리뷰어 에이전트를 참조하는지."""
+        path = SHARED_PATTERNS / "review-team-protocol.md"
+        content = path.read_text()
+        for agent in REVIEWER_AGENTS:
+            assert agent in content, (
+                f"Protocol should reference {agent}"
+            )
+
+    def test_skill_r3_mentions_explore_type(self):
+        """R3 모드가 Explore 타입을 사용하는지 명시."""
+        path = SKILL_DIR / "SKILL.md"
+        content = path.read_text()
+        assert "Explore" in content, (
+            "R3 mode should specify Explore agent type"
+        )


### PR DESCRIPTION
Closes #69

## Summary
- 역할별 리뷰어 에이전트 4개 신규: spec-reviewer, quality-reviewer, security-reviewer, maintainability-reviewer
- `review-team-protocol.md` 신규: TeamCreate → Agent spawn(Explore) → SendMessage 소통 → 결과 종합 → TeamDelete
- `requesting-code-review` SKILL.md에 R3 모드 추가 (기존 R1/R2/Ra 변경 없음)
- SDD 자동 호출 시 R1 기본값 명시, 에러 핸들링(TeamCreate/spawn 실패 → R1 fallback)
- 독립 분석 우선 원칙, cross-cutting issue 정의 기준, Critical fast-path 처리 명시

## Test plan
- [x] `uv run pytest -v` — 118 passed (21 신규 + 97 기존)
- [x] TestReviewerAgents: 4개 에이전트 파일 존재 + 필수 섹션 + 프롬프트 참조
- [x] TestReviewTeamProtocol: 프로토콜 파일 필수 섹션 + TeamCreate/SendMessage/TeamDelete 참조
- [x] TestR3ModeInSkill: SKILL.md R3 정의 + Agent Teams + 프로토콜 참조
- [x] TestR3Integration: graceful degradation + 리뷰어 참조 + Explore 타입

🤖 Generated with [Claude Code](https://claude.com/claude-code)