### PR TITLE
feat: session-summary 조기 업데이트 — 스테이지 내부 맥락 보존 (refs #40)

### DIFF
--- a/skills/_shared/patterns/session-continuity.md
+++ b/skills/_shared/patterns/session-continuity.md
@@ -55,12 +55,59 @@
 | 시점 | 트리거 |
 |------|--------|
 | INCEPTION 스테이지 완료 | Inception Orchestrator가 각 스테이지 게이트 승인 시 업데이트 (최초 생성 포함) |
+| **스테이지 내부 핵심 결정** | Stage Skill이 내부 핵심 결정 시점에 중간 기록 (조기 업데이트) |
 | Phase 전환 | INCEPTION → CONSTRUCTION 전환 시 Entry Orchestrator가 업데이트 |
 | Unit 완료 | Construction Orchestrator가 unit 구현 게이트 승인 시 업데이트 |
 | CONSTRUCTION 완료 | Entry Orchestrator가 최종 업데이트 |
 
 session-summary.md는 INCEPTION 첫 번째 스테이지 완료 시 생성됨.
 INCEPTION 중간에 세션이 끊겨도 재개 시 이 파일로 맥락 복원 가능.
+
+### 조기 업데이트 규약 (스테이지 내부 중간 기록)
+
+긴 스테이지 스킬이 내부 핵심 결정 시점에 session-summary.md를 업데이트한다.
+세션이 스테이지 도중에 끊겨도 맥락을 복원할 수 있도록 하기 위함.
+
+#### 스킬별 핵심 결정 시점
+
+| 스킬 | 중간 기록 시점 |
+|------|--------------|
+| `requirements-analysis` | 해석 분기 확정 후, 핵심 질문 답변 후 |
+| `application-design` | LIST 완료 후, DETAIL 주요 결정 후 |
+| `code-generation` | Plan 승인 후, TDD Step 완료마다 |
+
+#### 중간 기록 형식
+
+`## Completed Work` 섹션에 진행 중 스테이지를 `[~]` 마커로 표시한다:
+
+```markdown
+### INCEPTION
+- [x] workspace-detection — Brownfield
+- [~] requirements-analysis — 해석 확정(B안), 질문 2/5 완료
+```
+
+```markdown
+### CONSTRUCTION
+- [~] code-generation — Plan 승인, Step 3/8 완료
+```
+
+`## For Next Session` 섹션에 미결 맥락을 기록한다:
+
+```markdown
+## For Next Session
+- requirements-analysis: 질문 3~5 미답변. 질문 3은 "실시간 vs 배치" 선택
+- 주의: 해석 B안(REST API) 확정됨, 변경 불필요
+```
+
+#### 스킬 내 업데이트 지침 형식
+
+각 스킬에 아래 형태로 2~3줄만 추가한다:
+
+```markdown
+**session-summary 중간 기록**: [핵심 결정] 후 session-summary.md의
+`## Completed Work`에 `[~] [stage] — [진행 상황]` 업데이트 +
+`## For Next Session`에 미결 맥락 기록.
+```
 
 ### 파일 위치
 

--- a/skills/aidlc-application-design/SKILL.md
+++ b/skills/aidlc-application-design/SKILL.md
@@ -86,6 +86,8 @@ LIST 모드에서는 컴포넌트 목록을 `devflow-docs/inception/application-
 | [Name] | [한 줄 책임] | [Type] |
 ```
 
+**session-summary 중간 기록**: LIST 완료 후 session-summary.md의 `## Completed Work`에 `[~] application-design — LIST 완료 ([N]개 컴포넌트)` 업데이트.
+
 → Return to Orchestrator (목록 반환)
 
 ### Step 4: DETAIL Mode — 상세 설계
@@ -151,6 +153,8 @@ DETAIL 모드에서만 실행.
 conventions Review Workflow 적용.
 - 산출물: devflow-docs/inception/application-design.md
 - 리뷰어: artifact-reviewer-prompt.md
+
+**session-summary 중간 기록**: DETAIL 모드에서 각 컴포넌트 상세 설계 완료 시 `[~] application-design — DETAIL [N]/[M] 컴포넌트 완료` 업데이트.
 
 ## Return to Orchestrator
 

--- a/skills/aidlc-code-generation/SKILL.md
+++ b/skills/aidlc-code-generation/SKILL.md
@@ -66,6 +66,8 @@ After writing the plan, display it and STOP:
 
 The orchestrator will present the approval gate. Do NOT write any code yet.
 
+**session-summary 중간 기록**: Plan 작성 완료 후 session-summary.md의 `## Completed Work`에 `[~] code-generation — Plan 작성 완료, 승인 대기` 업데이트.
+
 ### PART 2 — Generation (오케스트레이터 승인 후)
 
 When invoked with explicit generation instruction such as:
@@ -79,6 +81,7 @@ orchestrator has signaled to proceed with generation.
    b. GREEN: 최소 구현 → 실행 → 해당 테스트 + 전체 테스트 통과 확인
    c. REFACTOR: 정리 → 전체 테스트 재실행
    d. 체크박스 [x] 표시 (하위 RED/Verify RED/GREEN/Verify GREEN/REFACTOR 포함)
+   e. **session-summary 중간 기록**: Step 완료마다 `[~] code-generation — Step [N]/[M] 완료` 업데이트
 3. Iron Law 위반 시: 해당 코드 삭제 후 RED부터 재시작
 4. 모든 Step 완료 후 Self-Review 체크리스트 수행 (`_shared/tdd-protocol.md` 참조)
 5. 자가 수정 후 Save plan progress to `devflow-docs/construction/[unit-name]/code-plan.md`

--- a/skills/aidlc-requirements-analysis/SKILL.md
+++ b/skills/aidlc-requirements-analysis/SKILL.md
@@ -95,6 +95,8 @@ C) [해석 3] — [한 줄 설명, 있는 경우]
 
 선택된 해석을 requirements.md의 `## User Intent`에 반영한다.
 
+**session-summary 중간 기록**: 해석 확정 후 session-summary.md의 `## Completed Work`에 `[~] requirements-analysis — 해석 확정([선택]안)` 업데이트 + `## For Next Session`에 미결 질문 목록 기록.
+
 #### Ambiguity Resolution Loop (Standard / Comprehensive)
 
 해석 선택 후, 다음 모호성 신호를 탐지한다:
@@ -132,6 +134,7 @@ A와 B 중에서 상충할 때 어느 쪽을 우선하시겠어요?
    - 처리 방식: "실시간 처리가 필요한가요, 배치로 충분한가요?"
    - 사용자 유형: "단일 사용자인가요, 다중 사용자인가요?"
    - 각 답변 후 Ambiguity Resolution Loop 발동 여부 판단.
+   - **session-summary 중간 기록**: 각 핵심 질문 답변 후 `[~] requirements-analysis — 질문 N/M 완료` 업데이트.
 
 #### Comprehensive
 1. Full intent analysis (Step 2에서 확정된 해석 기반)


### PR DESCRIPTION
스테이지 진행 중 세션 끊김 시 내부 맥락 유실 문제 해결.
JSONL 신규 파일 도입 대신 기존 session-summary.md의 업데이트 타이밍을 스테이지 완료 시점에서 내부 핵심 결정 시점으로 앞당김.

- session-continuity.md: 조기 업데이트 규약 + 스킬별 핵심 결정 시점 테이블 + [~] 진행 중 마커 형식
- requirements-analysis: 해석 분기 확정 후, 핵심 질문 답변 후 중간 기록
- application-design: LIST 완료 후, DETAIL 컴포넌트 완료마다 중간 기록
- code-generation: Plan 완료 후, TDD Step 완료마다 중간 기록