### PR TITLE
feat: INCEPTION 산출물 재호출 시 UPDATE 모드 추가

### DIFF
--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -122,7 +122,7 @@ Complexity 값을 requirements-analysis 호출 시 인라인으로 전달: `"Com
 <!-- @gate: requirements-analysis -->
 <!-- @gate-option: A -> requirements-analysis {questions} -->
 <!-- @gate-option: B -> pre-planning -->
-<!-- @gate-option: C -> requirements-analysis {변경요청} -->
+<!-- @gate-option: C -> requirements-analysis {UPDATE} -->
 
 패턴: `열린 질문: [N]개`
 
@@ -133,25 +133,30 @@ Complexity 값을 requirements-analysis 호출 시 인라인으로 전달: `"Com
 [requirements-analysis 결과 표시]
 A) 미해결 질문 처리 → aidlc-requirements-analysis: QUESTIONS 재호출
 B) 현재 가정으로 유지하고 다음 단계로 진행
-C) 변경 요청 (예: 요구사항 추가/삭제, 우선순위 변경 등) → requirements-analysis 재호출
+C) 변경 요청 (예: 요구사항 추가/삭제, 우선순위 변경 등) → requirements-analysis UPDATE 재호출
 ```
 
 A) 선택 시: `"aidlc-requirements-analysis: QUESTIONS — 기존 분석 유지, 미해결 질문만 처리"` 인라인 신호로 재호출 → 반환 → `열린 질문: [N]개` 패턴 재확인
+C) 선택 시: `"aidlc-requirements-analysis: UPDATE — 기존 분석 유지, [사용자 변경 요청 내용] 반영"` 인라인 신호로 재호출
 
 **N == 0이고 가정 있음:**
 ```
 [requirements-analysis 결과 표시]
 가정으로 처리된 항목이 있습니다: [목록]
-A) 가정 수정 → requirements-analysis 재호출
+A) 가정 수정 → requirements-analysis UPDATE 재호출
 B) 가정 승인, 다음 단계 진행
 ```
+
+A) 선택 시: `"aidlc-requirements-analysis: UPDATE — 기존 분석 유지, [사용자 변경 요청 내용] 반영"` 인라인 신호로 재호출
 
 **N == 0이고 가정 없음:**
 ```
 [requirements-analysis 결과 표시]
-A) 변경 요청 (예: 요구사항 추가/삭제, 우선순위 변경 등) → requirements-analysis 재호출
+A) 변경 요청 (예: 요구사항 추가/삭제, 우선순위 변경 등) → requirements-analysis UPDATE 재호출
 B) 승인, 다음 단계 진행
 ```
+
+A) 선택 시: `"aidlc-requirements-analysis: UPDATE — 기존 분석 유지, [사용자 변경 요청 내용] 반영"` 인라인 신호로 재호출
 
 ### 4. Pre-Planning 분기 [자동분기 + 조건부 게이트]
 <!-- @gate: pre-planning -->
@@ -185,7 +190,7 @@ C → workflow-planning으로 직행
 
 ### 5. User-Stories 게이트 [표준 게이트 + Hold]
 <!-- @gate: user-stories -->
-<!-- @gate-option: A -> user-stories {재호출} -->
+<!-- @gate-option: A -> user-stories {UPDATE} -->
 <!-- @gate-option: B -> nfr-requirements -->
 <!-- @gate-option: H -> nfr-requirements {held} -->
 
@@ -194,10 +199,12 @@ aidlc-user-stories 호출 → 결과 게이트:
 
 ```
 [user-stories 결과 표시]
-A) 변경 요청 (예: 스토리 분할, 수용 기준 수정, 액터 변경 등) → user-stories 재호출
+A) 변경 요청 (예: 스토리 분할, 수용 기준 수정, 액터 변경 등) → user-stories UPDATE 재호출
 B) 승인, 다음 단계 진행 → NFR-Requirements 게이트
 H) 보류 (나중에 돌아옴) → HELD 상태 저장, NFR-Requirements 게이트로 진행
 ```
+
+A) 선택 시: `"aidlc-user-stories: UPDATE — 기존 스토리 유지, [사용자 변경 요청 내용] 반영"` 인라인 신호로 재호출
 
 ### 6. NFR-Requirements 게이트 [모드 선택 게이트 + 표준 게이트 + Hold]
 <!-- @gate: nfr-requirements-mode -->

--- a/skills/aidlc-requirements-analysis/SKILL.md
+++ b/skills/aidlc-requirements-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: aidlc-requirements-analysis
 description: Use when user requirements need to be analyzed, structured into a requirements document, or when open questions from a previous analysis need resolution.
 metadata:
-  version: 0.5.0
+  version: 0.6.0
   author: Jay
   category: ai-dlc-workflow
   invoke_mode: orchestrator-only
@@ -37,6 +37,29 @@ Step 1, 2, 3, 4는 실행하지 않는다.
 
 ### QUESTIONS 모드 반환값
 미해결 질문이 남아있으면 `열린 질문: [N]개` 패턴을 포함하여 반환. 모두 해결되면 `열린 질문: 0개`.
+
+### UPDATE 모드
+호출 텍스트에 `UPDATE` 키워드 포함 시 활성화:
+`"aidlc-requirements-analysis: UPDATE — 기존 분석 유지, [변경 내용] 반영"`
+
+UPDATE 모드에서는:
+1. `devflow-docs/inception/requirements.md` 읽기 (기존 분석)
+2. 변경 요청과 기존 요구사항을 대조하여 **연관성 판단**:
+   - **연관 요구사항 있음** (동일 기능/영역) → 해당 항목을 기반으로 수정/확장 (우선순위 변경, 기준 보강 등). Edit 도구로 해당 섹션만 교체
+   - **연관 요구사항 없음** (새로운 기능) → 신규 항목으로 기존 목록에 추가. Edit 도구로 삽입
+   - **요구사항 삭제** → 해당 항목 삭제 + 연쇄 영향 확인 (Assumptions, Open Questions에서 관련 항목 제거/갱신)
+3. 변경이 다른 섹션에 영향을 주는지 확인:
+   - Assumptions: 변경으로 무효화된 가정이 있으면 제거 또는 갱신
+   - Open Questions: 변경에서 새 질문이 발생하면 추가
+   - Technology Stack, Non-Functional Requirements: 영향이 있으면 갱신
+4. `## Change Log` 섹션에 변경 내역 기록: `- [ISO 8601] UPDATE: [변경 요약]`
+5. `requirements.md` 업데이트 후 STOP
+
+**도구 선택**: 부분 업데이트에는 반드시 Edit 도구를 사용한다. Write 도구로 전체 덮어쓰기 금지.
+
+Step 1, 2, 3, 4, 5는 실행하지 않는다.
+
+**UPDATE 범위 제한**: User Intent 자체를 변경하는 요청은 UPDATE 대상이 아니다. "방향을 바꾸고 싶다"는 요청에는 "전체 재분석이 필요합니다"라고 안내하고 일반 모드로 재호출을 유도한다.
 
 ## Execute
 

--- a/skills/aidlc-user-stories/SKILL.md
+++ b/skills/aidlc-user-stories/SKILL.md
@@ -2,7 +2,7 @@
 name: aidlc-user-stories
 description: Use when requirements need to be converted into INVEST-compliant user stories with acceptance criteria.
 metadata:
-  version: 0.6.0
+  version: 0.7.0
   author: Jay
   category: ai-dlc-workflow
   invoke_mode: orchestrator-only
@@ -23,6 +23,24 @@ metadata:
 ### IMPORT 모드
 User-stories는 IMPORT 미지원. requirements-analysis 결과를 기반으로 생성하는 것이 핵심 가치.
 IMPORT 신호 수신 시: "User-stories는 IMPORT 미지원입니다. GENERATE 모드로 실행합니다." 메시지 후 GENERATE 진행.
+
+### UPDATE 모드
+호출 텍스트에 `UPDATE` 키워드 포함 시 활성화:
+`"aidlc-user-stories: UPDATE — 기존 스토리 유지, [변경 내용] 반영"`
+
+UPDATE 모드에서는:
+1. `devflow-docs/inception/user-stories.md` 읽기 (기존 스토리)
+2. `devflow-docs/inception/requirements.md` 읽기 (변경된 요구사항)
+3. 변경 요청과 기존 스토리를 대조하여 **연관성 판단**:
+   - **연관 스토리 있음** (동일 액터/기능 범위) → 해당 스토리를 기반으로 수정/확장 (수용 기준 보강, 우선순위 변경 등). Edit 도구로 해당 섹션만 교체
+   - **연관 스토리 없음** (새로운 액터/기능) → 신규 스토리로 기존 목록에 추가 (번호는 기존 마지막 번호 이후부터). Edit 도구로 삽입
+   - **요구사항 삭제로 스토리가 불필요** → 해당 스토리 삭제 (번호 재부여 안 함)
+4. `## Change Log` 섹션에 변경 내역 기록: `- [ISO 8601] UPDATE: [변경 요약]`
+5. `user-stories.md` 업데이트 후 STOP
+
+**도구 선택**: 부분 업데이트에는 반드시 Edit 도구를 사용한다. Write 도구로 전체 덮어쓰기 금지.
+
+Step 1, 2, 3, 4는 실행하지 않는다.
 
 ## Execute
 
@@ -76,6 +94,11 @@ Create `devflow-docs/inception/user-stories.md`:
 - Given [context], When [action], Then [result]
 **Priority**: [Must | Should | Could]
 ```
+
+### Step 4 참고: 기존 파일이 존재할 때
+
+인라인 신호 없이 재호출되었는데 `user-stories.md`가 이미 존재하면 **UPDATE로 간주**한다.
+기존 내용 보존이 기본값이다.
 
 ## Review
 


### PR DESCRIPTION
Closes #79

## Summary
- requirements-analysis, user-stories에 UPDATE 모드 추가 — 게이트 변경 요청 시 기존 산출물을 전체 재생성하지 않고 연관성 판단 후 부분 수정/확장
- inception-orchestrator 게이트에 UPDATE 인라인 신호 추가
- units-generation, workflow-planning은 분석 후 의도적으로 제외 (승인 전 재호출만 발생, 전체 재생성이 더 안전)

## Test plan
- [x] requirements-analysis SKILL.md에 UPDATE 모드 섹션이 QUESTIONS 모드와 동일한 구조로 존재하는지 확인
- [x] user-stories SKILL.md에 UPDATE 모드 섹션이 존재하고 Edit 도구 강제 규칙이 포함되는지 확인
- [x] inception-orchestrator의 requirements-analysis 게이트 C 옵션에 UPDATE 인라인 신호가 포함되는지 확인
- [x] inception-orchestrator의 user-stories 게이트 A 옵션에 UPDATE 인라인 신호가 포함되는지 확인
- [x] requirements-analysis UPDATE 모드에 User Intent 변경 시 일반 모드 안내 제한 규칙이 있는지 확인
- [x] 실제 devflow 실행으로 UPDATE 모드 동작 검증 (다음 프로젝트에서 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)