### PR TITLE
fix: inception 시나리오 workspace-detection 게이트 선택지 정합성 수정

### DIFF
--- a/tests/scenarios/inception-complexity-adjust.yaml
+++ b/tests/scenarios/inception-complexity-adjust.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: C

--- a/tests/scenarios/inception-comprehensive-all.yaml
+++ b/tests/scenarios/inception-comprehensive-all.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Comprehensive
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     user-stories: B

--- a/tests/scenarios/inception-interrupt-at-requirements.yaml
+++ b/tests/scenarios/inception-interrupt-at-requirements.yaml
@@ -6,7 +6,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: X
 expect:

--- a/tests/scenarios/inception-minimal-fast.yaml
+++ b/tests/scenarios/inception-minimal-fast.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Minimal
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
 expect:

--- a/tests/scenarios/inception-nfr-skip.yaml
+++ b/tests/scenarios/inception-nfr-skip.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: B

--- a/tests/scenarios/inception-requirements-questions.yaml
+++ b/tests/scenarios/inception-requirements-questions.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: C

--- a/tests/scenarios/inception-standard-full.yaml
+++ b/tests/scenarios/inception-standard-full.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: C

--- a/tests/scenarios/inception-standard-nfr-only.yaml
+++ b/tests/scenarios/inception-standard-nfr-only.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: B

--- a/tests/scenarios/inception-standard-user-stories.yaml
+++ b/tests/scenarios/inception-standard-user-stories.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: A

--- a/tests/scenarios/inception-workspace-retry.yaml
+++ b/tests/scenarios/inception-workspace-retry.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: C

--- a/tests/scenarios/inception-worktree-setup.yaml
+++ b/tests/scenarios/inception-worktree-setup.yaml
@@ -3,7 +3,7 @@ orchestrator: aidlc-inception-orchestrator
 inputs:
   complexity: Standard
   choices:
-    workspace-detection: B
+    workspace-detection: C
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: C

--- a/tests/test_graph_validator.py
+++ b/tests/test_graph_validator.py
@@ -147,9 +147,10 @@ class TestNoDeadEnds:
     def test_no_dead_ends(self, load_graph, name):
         graph = load_graph(name)
         node_ids = collect_node_ids(graph)
+        ext_refs = set(graph.get("externalRefs", []))
         dead_ends = [
             t for t in collect_targets(graph)
-            if t not in node_ids and not is_external_ref(t) and not skill_exists(t)
+            if t not in node_ids and t not in ext_refs and not is_external_ref(t) and not skill_exists(t)
         ]
         assert dead_ends == [], f"Dead-end targets in {name}: {dead_ends}"
 
@@ -181,9 +182,10 @@ class TestNoUnknownRefs:
     def test_no_unknown_refs(self, load_graph, name):
         graph = load_graph(name)
         node_ids = collect_node_ids(graph)
+        ext_refs = set(graph.get("externalRefs", []))
         unknown = [
             t for t in collect_targets(graph)
-            if t not in node_ids and not is_external_ref(t) and not skill_exists(t)
+            if t not in node_ids and t not in ext_refs and not is_external_ref(t) and not skill_exists(t)
         ]
         assert unknown == [], f"Unknown external refs in {name}: {unknown}"
 


### PR DESCRIPTION
480fdef에서 workspace-detection 게이트에 reverse-engineering B 옵션이 추가되면서 기존 B(확인)가 C로 이동했으나, 테스트 시나리오가 미업데이트.

- tests/scenarios/inception-*.yaml: workspace-detection B → C (11개 파일)
- tests/test_graph_validator.py: externalRefs 필드 지원 추가