### PR TITLE
feat: Verification Contract + Self-Healing Loop (#87, #88)

### DIFF
--- a/skills/_shared/reviewers/code-plan-reviewer-prompt.md
+++ b/skills/_shared/reviewers/code-plan-reviewer-prompt.md
@@ -23,6 +23,7 @@
 | **파일 구조** | 파일 경로 명확, 단일 책임, 과도한 크기 아님 |
 | **검증 단계** | 각 태스크에 검증 방법 포함 |
 | **TDD 사이클** | 각 Implementation Step이 RED-GREEN-REFACTOR 하위 단계를 포함하는가 |
+| **Verification Contract** | `## Verification Contract` 섹션 존재. 완료 조건 1개 이상, 검증 명령 1개 이상 필수 |
 
 ## 출력 형식
 

--- a/skills/aidlc-build-and-test/SKILL.md
+++ b/skills/aidlc-build-and-test/SKILL.md
@@ -28,6 +28,7 @@ Execute build and full test suite after all units are implemented, then generate
 2. **소스 파일** — `.py`, `.go`, `.ts`, `.js`, `.rs`, `.java`
 3. **Code plans** — `devflow-docs/construction/*/code-plan.md`에서 생성된 파일 목록
 4. **units.md** — `devflow-docs/inception/units.md` (있으면) — unit 간 통합 포인트
+5. **Verification Contract** — `devflow-docs/construction/{unit}/code-plan.md`의 `## Verification Contract` 섹션을 확인한다. 섹션이 있으면 검증 명령을 Step 3에서 우선 사용한다. 섹션이 없으면 기존 동작(프로젝트 타입 자동 감지)을 유지한다. auto-fix 후 재실행 시에도 Verification Contract의 검증 명령 전체를 다시 실행한다.
 
 ### Step 2: 빌드 실행
 
@@ -97,6 +98,7 @@ Run: `[정확한 명령어]`
 conventions 표준 형식. 반환 필드:
 - 빌드: ✅ 성공 | ❌ 실패 ([에러 요약])
 - 테스트: ✅ [N]개 통과, 0 실패 | ❌ [N]개 통과, [M]개 실패
+- Verification Contract: [완료 조건 pass/fail 체크리스트] (계약이 있는 경우에만 포함)
 - 산출물: build-instructions.md, test-instructions.md
 
 ## Error Handling

--- a/skills/aidlc-code-generation/SKILL.md
+++ b/skills/aidlc-code-generation/SKILL.md
@@ -53,6 +53,20 @@ Create a code generation plan with checkboxes:
 - [ ] [test name]: [what it verifies]
 
 > 각 테스트는 Implementation Steps의 RED 단계에서 작성된다. 별도 테스트 단계가 아님.
+
+## Verification Contract
+
+### 완료 조건
+- [ ] [구체적 기능 요건 1]
+- [ ] [구체적 기능 요건 2]
+
+### 검증 명령
+- `[test command]` — [what it verifies]
+- `[lint command]` — [what it checks]
+
+### 리스크 태그
+- [ ] auth/security — [해당 시 표시]
+- [ ] DB schema change — [해당 시 표시]
 ```
 
 After writing the plan, display it and STOP:
@@ -72,6 +86,11 @@ The orchestrator will present the approval gate. Do NOT write any code yet.
 
 When invoked with explicit generation instruction such as:
 `"code-generation: GENERATE — proceed with the approved plan for [unit-name]"`
+
+Or when invoked with auto-fix error context:
+`"code-generation: GENERATE — auto-fix for [unit-name]: [failed test], [error summary]"`
+
+When error context is present, fix only the failing part instead of re-executing the full plan. Use the error message and failed test name to identify the affected Implementation Step.
 
 Or when the conversation context clearly contains an approved plan and the
 orchestrator has signaled to proceed with generation.

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -183,23 +183,53 @@ Council 리뷰 결과는 사용자 승인 후 게이트를 재표시한다.
 
 `aidlc-build-and-test` 호출
 
+#### 3a. Auto-fix 전처리 (Self-Healing Loop)
+
+build-and-test 결과를 받은 후, 완료 게이트를 표시하기 **전에** 자동 수정을 시도한다.
+
+**즉시 게이트로 전달 (auto-fix 스킵):**
+- 빌드 실패 (컴파일 에러, 설정 문제, 의존성 누락)
+- 환경 문제 (missing binary, permission denied)
+- 리스크 태그에 `auth/security` 표시된 unit의 오류
+- 에러 메시지에 `auth`, `permission`, `forbidden`, `unauthorized` 키워드 포함 시 (리스크 태그 누락 방어)
+
+**auto-fix 대상 (코드 수정으로 해결 가능한 객관적 오류):**
+- 테스트 실패 (assertion error, runtime error in tests)
+- 린트 에러 (formatting, unused imports, type errors)
+
+**auto-fix 루프 (최대 3회):**
+1. 실패한 테스트명 + 에러 메시지 추출
+2. `code-generation: GENERATE — auto-fix for [unit-name]: [실패 테스트명], [에러 메시지 요약]` 재호출
+3. `aidlc-build-and-test` 재실행
+4. 종료 조건 확인:
+   - 성공 → 완료 게이트 (성공 분기)로 전달. `"(auto-fix [N]회 적용됨)"` 안내 추가
+   - plateau (연속 2회 동일 테스트명 집합 실패, 또는 실패 수가 감소하지 않음) → 완료 게이트 (실패 분기)로 전달
+   - 3회 도달 → 완료 게이트 (실패 분기)로 전달
+5. 각 시도를 devflow-audit에 기록: `[timestamp] auto-fix attempt [N]/3: [에러 요약] → [수정 내용]`
+6. auto-fix 루프 내에서 code-generation 호출이 실패하면 즉시 루프 중단 후 완료 게이트(실패 분기)로 전달
+7. 루프 완료 시 session-summary에 `auto-fix [N]회 적용` 형태로 요약 기록
+
+auto-fix 실패 시 완료 게이트에 실패 보고서(시도한 수정 목록, 각 시도 결과) 추가 표시.
+
 #### 완료 게이트 [조건부 게이트]
 <!-- @gate: build-and-test-result -->
 <!-- @gate-option: A -> CONSTRUCTION-complete -->
 <!-- @gate-option: B -> code-generation-plan {추가수정} -->
 
-build-and-test 결과에 따라 분기:
+build-and-test 결과 (auto-fix 전처리 후)에 따라 분기:
 
 **빌드 성공 + 테스트 전체 통과 시:**
 ```
 [build-and-test 결과 표시]
+(auto-fix [N]회 적용됨 — 해당 시에만 표시)
 A) CONSTRUCTION 완료 승인
 B) 추가 변경 요청 (예: 테스트 보완, 성능 개선 등) → code-generation 재호출
 ```
 
-**테스트 실패 시:**
+**테스트 실패 시 (auto-fix 소진 포함):**
 ```
 [build-and-test 결과 표시 — 실패 테스트 목록 포함]
+[auto-fix 실패 보고서 — 해당 시에만 표시]
 A) systematic-debugging으로 조사
 B) 실패를 무시하고 완료 (devflow-state에 "테스트 실패 [N]건 미해결" 기록)
 ```
@@ -213,7 +243,7 @@ A) systematic-debugging으로 조사
 
 ### Debugging 라우팅
 
-build-and-test에서 테스트/빌드 실패 시 사용자가 debugging을 선택하면:
+build-and-test에서 테스트/빌드 실패 시 (auto-fix 소진 후) 사용자가 debugging을 선택하면:
 
 1. `aidlc-systematic-debugging` 호출
 2. debugging 완료 시 Return 수신:

--- a/tests/parse-skills.js
+++ b/tests/parse-skills.js
@@ -173,6 +173,13 @@ for (const filePath of skillFiles) {
     graph.conditions.length > 0
   ) {
     const outputPath = join(outputDir, `${graph.name}.json`);
+    // Preserve externalRefs from existing JSON if present
+    try {
+      const existing = JSON.parse(readFileSync(outputPath, "utf-8"));
+      if (existing.externalRefs) {
+        graph.externalRefs = existing.externalRefs;
+      }
+    } catch (_) { /* file doesn't exist yet, skip */ }
     writeFileSync(outputPath, JSON.stringify(graph, null, 2) + "\n");
     parsedCount++;
   }

--- a/tests/scenarios/construction-auto-fix-escalation.yaml
+++ b/tests/scenarios/construction-auto-fix-escalation.yaml
@@ -1,0 +1,18 @@
+# Note: auto-fix loop is transparent preprocessing inside orchestrator,
+# not modeled by L2 routing engine. This scenario verifies the gate path
+# after auto-fix exhaustion (same as normal failure path).
+name: "Construction — Auto-fix exhausted, escalation to user gate"
+orchestrator: aidlc-construction-orchestrator
+inputs:
+  complexity: Standard
+  choices:
+    units-generation: B
+    code-plan: B
+    code-generation-result: B
+    build-and-test-result: A
+expect:
+  stage_path:
+    - context-load
+    - revalidation
+    - stage-decision
+  final_stage: stage-decision

--- a/tests/scenarios/construction-auto-fix-success.yaml
+++ b/tests/scenarios/construction-auto-fix-success.yaml
@@ -1,0 +1,18 @@
+# Note: auto-fix loop is transparent preprocessing inside orchestrator,
+# not modeled by L2 routing engine. This scenario verifies the gate path
+# after successful auto-fix (same as normal success path).
+name: "Construction — Auto-fix success after test failure"
+orchestrator: aidlc-construction-orchestrator
+inputs:
+  complexity: Standard
+  choices:
+    units-generation: B
+    code-plan: B
+    code-generation-result: B
+    build-and-test-result: A
+expect:
+  stage_path:
+    - context-load
+    - revalidation
+    - stage-decision
+  final_stage: stage-decision

--- a/tests/test_verification_contract.py
+++ b/tests/test_verification_contract.py
@@ -1,0 +1,185 @@
+"""Verification Contract and Self-Healing Loop validation tests.
+
+Validates that:
+- code-generation Plan template includes Verification Contract section
+- code-plan-reviewer checks Verification Contract existence/completeness
+- build-and-test references Verification Contract from code-plan
+- construction-orchestrator includes auto-fix preprocessing before completion gate
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+
+def read_skill(name: str) -> str:
+    """Read a SKILL.md file content."""
+    path = SKILLS_DIR / name / "SKILL.md"
+    return path.read_text(encoding="utf-8")
+
+
+def read_shared(relative_path: str) -> str:
+    """Read a file from _shared directory."""
+    path = SKILLS_DIR / "_shared" / relative_path
+    return path.read_text(encoding="utf-8")
+
+
+# --- FR-1: Verification Contract in code-generation Plan template ---
+
+
+class TestVerificationContractTemplate:
+    """code-generation Plan template must include Verification Contract section."""
+
+    def test_plan_template_has_verification_contract_section(self):
+        content = read_skill("aidlc-code-generation")
+        assert "## Verification Contract" in content, (
+            "code-generation SKILL.md must include '## Verification Contract' in Plan template"
+        )
+
+    def test_verification_contract_has_completion_criteria(self):
+        content = read_skill("aidlc-code-generation")
+        assert re.search(r"완료 조건|completion criteria", content, re.IGNORECASE), (
+            "Verification Contract must include completion criteria"
+        )
+
+    def test_verification_contract_has_verification_commands(self):
+        content = read_skill("aidlc-code-generation")
+        assert re.search(r"검증 명령|verification command", content, re.IGNORECASE), (
+            "Verification Contract must include verification commands"
+        )
+
+    def test_verification_contract_has_risk_tags(self):
+        content = read_skill("aidlc-code-generation")
+        assert re.search(r"리스크 태그|risk tag", content, re.IGNORECASE), (
+            "Verification Contract must include risk tags"
+        )
+
+
+# --- FR-1a: code-plan-reviewer checks Verification Contract ---
+
+
+class TestCodePlanReviewerContract:
+    """code-plan-reviewer must check Verification Contract existence."""
+
+    def test_reviewer_checks_verification_contract(self):
+        content = read_shared("reviewers/code-plan-reviewer-prompt.md")
+        assert "Verification Contract" in content, (
+            "code-plan-reviewer must check Verification Contract section"
+        )
+
+
+# --- FR-2: build-and-test references Verification Contract ---
+
+
+class TestBuildAndTestContractReference:
+    """build-and-test must reference Verification Contract from code-plan."""
+
+    def test_references_verification_contract(self):
+        content = read_skill("aidlc-build-and-test")
+        assert "Verification Contract" in content, (
+            "build-and-test must reference Verification Contract"
+        )
+
+    def test_graceful_fallback_when_no_contract(self):
+        content = read_skill("aidlc-build-and-test")
+        assert re.search(r"없으면|fallback|기존 동작", content), (
+            "build-and-test must have graceful fallback when no Verification Contract"
+        )
+
+    def test_rerun_full_verification_on_auto_fix(self):
+        """auto-fix 후 재실행 시에도 검증 명령 전체를 다시 실행해야 한다."""
+        content = read_skill("aidlc-build-and-test")
+        assert re.search(r"auto-fix.*재실행|다시 실행|전체를 다시", content), (
+            "build-and-test must mention re-running full verification after auto-fix"
+        )
+
+
+# --- FR-3: code-generation auto-fix signal ---
+
+
+class TestCodeGenerationAutoFixSignal:
+    """code-generation must accept auto-fix error context in GENERATE signal."""
+
+    def test_auto_fix_signal_format_documented(self):
+        content = read_skill("aidlc-code-generation")
+        assert re.search(r"auto-fix for \[unit-name\]", content), (
+            "code-generation must document auto-fix signal format"
+        )
+
+    def test_partial_fix_behavior_documented(self):
+        """에러 컨텍스트가 있으면 해당 부분만 수정해야 한다."""
+        content = read_skill("aidlc-code-generation")
+        assert re.search(r"해당 부분만 수정|fix only the failing", content), (
+            "code-generation must document partial fix behavior for auto-fix"
+        )
+
+
+# --- FR-3/FR-4: Self-Healing Loop in construction-orchestrator ---
+
+
+class TestSelfHealingLoop:
+    """construction-orchestrator must include auto-fix preprocessing."""
+
+    def test_auto_fix_section_exists(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"auto-fix|Self-Healing|자동 수정", content), (
+            "construction-orchestrator must include auto-fix/Self-Healing section"
+        )
+
+    def test_max_retry_defined(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"max.?retry|최대.*재시도|3회", content), (
+            "construction-orchestrator must define max retry count"
+        )
+
+    def test_plateau_detection_defined(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"plateau|동일.*에러.*패턴", content), (
+            "construction-orchestrator must define plateau detection"
+        )
+
+    def test_structural_problem_escalation(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"빌드 실패|구조적 문제|즉시.*에스컬레이션|structural", content), (
+            "construction-orchestrator must escalate structural problems immediately"
+        )
+
+    def test_existing_gate_structure_preserved(self):
+        """Existing 3-branch completion gate must be preserved."""
+        content = read_skill("aidlc-construction-orchestrator")
+        assert "systematic-debugging" in content, (
+            "Existing debugging routing must be preserved"
+        )
+        assert re.search(r"CONSTRUCTION.*완료.*승인|CONSTRUCTION-complete", content), (
+            "Existing completion approval must be preserved"
+        )
+
+    def test_audit_logging_for_auto_fix(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"auto-fix.*audit|audit.*auto-fix|자동 수정.*기록", content), (
+            "Auto-fix attempts must be logged to audit"
+        )
+
+    def test_environment_problem_escalation(self):
+        """환경 문제(missing binary, permission denied)는 즉시 에스컬레이션."""
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"환경 문제|missing binary|permission denied", content), (
+            "construction-orchestrator must escalate environment problems immediately"
+        )
+
+    def test_auth_security_risk_tag_escalation(self):
+        """auth/security 리스크 태그가 있는 unit은 auto-fix를 시도하지 않는다."""
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"auth/security", content), (
+            "construction-orchestrator must mention auth/security risk tag escalation"
+        )
+
+    def test_auto_fix_success_message_format(self):
+        """auto-fix 성공 시 '(auto-fix [N]회 적용됨)' 안내가 있어야 한다."""
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"auto-fix.*회.*적용", content), (
+            "construction-orchestrator must show auto-fix count on success"
+        )


### PR DESCRIPTION
Closes #87
Closes #88

## Summary
- **BL-047 Verification Contract**: code-generation Plan 템플릿에 검증 계약 섹션 추가 (완료 조건, 검증 명령, 리스크 태그). build-and-test가 계약을 참조하여 pass/fail 판정. code-plan-reviewer에 체크 항목 추가
- **BL-048 Self-Healing Loop**: construction-orchestrator에 auto-fix 전처리 삽입. 테스트/린트 실패 시 최대 3회 자동 재시도. 구조적 문제/auth·security는 즉시 에스컬레이션. 기존 3분기 게이트 구조 유지 (투명한 전처리)
- **기존 결함 수정**: parse-skills.js에 externalRefs 보존 로직 추가 (inception graph의 reverse-engineering 외부 참조)

## Test plan
- [x] 139 tests passed (19 new + 120 existing), 0 failed
- [x] R1 3-stage code review 통과 (Spec + Quality + Security)
- [x] Verification Contract 완료 조건 8/8 달성
- [x] 기존 L2 시나리오 (construction-single-unit, multi-unit, comprehensive) 회귀 없음
- [x] 신규 L2 시나리오 (auto-fix-success, auto-fix-escalation) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)