### PR TITLE
feat: SDD Default + Quantitative Rubric (closes #89, closes #90)

### DIFF
--- a/skills/_shared/patterns/review-feedback-schema.md
+++ b/skills/_shared/patterns/review-feedback-schema.md
@@ -1,0 +1,96 @@
+# Review Feedback Schema
+
+<!-- Single Source of Truth for reviewer output format. All 4 code reviewers reference this file. -->
+
+## Purpose
+
+Define the standardized output format, verdict criteria, and scoring rubric for all code reviewers. Each reviewer reads this file and follows the format exactly.
+
+## Output Template
+
+```markdown
+## Review Result
+
+**Verdict**: PASS | CONDITIONAL | FAIL
+
+### Score
+
+| Item | Rating | Notes |
+|------|--------|-------|
+| [rubric item] | 🟢 Good / 🟡 Acceptable / 🔴 Needs Work | [brief justification] |
+
+### Context
+[Optional — domain-specific summary. Security: Threat Surface. Maintainability: Change Impact Summary. 2-3 sentences max.]
+
+### Issues
+
+| # | Severity | File:Line | Issue | Fix |
+|---|----------|-----------|-------|-----|
+| 1 | Critical | path:42 | description | recommended fix |
+
+### Pass Criteria
+- [x] [met criterion]
+- [ ] [unmet criterion]
+```
+
+## Verdict Criteria
+
+| Verdict | Condition |
+|---------|-----------|
+| **PASS** | 0 Critical issues AND 0 🔴 rubric items |
+| **CONDITIONAL** | 0 Critical issues AND 1+ 🔴 rubric items |
+| **FAIL** | 1+ Critical issues |
+
+When aggregating across multiple reviewers (synthesis), use **worst-of** logic: if any reviewer returns FAIL, the aggregate is FAIL.
+
+## Issue Severity
+
+| Level | Definition | Action |
+|-------|-----------|--------|
+| **Critical** | Bugs, security vulnerabilities, data loss risk | Must fix before merge |
+| **Important** | Architecture, test gaps, error handling | Should fix |
+| **Minor** | Style, naming, optimization | Optional |
+
+## Score Levels
+
+| Level | Symbol | Meaning |
+|-------|--------|---------|
+| Good | 🟢 | Meets or exceeds expectations |
+| Acceptable | 🟡 | Adequate but could improve |
+| Needs Work | 🔴 | Below threshold, contributes to CONDITIONAL verdict |
+
+---
+
+## Reviewer-Specific Rubrics
+
+### Spec Compliance Reviewer
+
+| Rubric Item | 🟢 Good | 🟡 Acceptable | 🔴 Needs Work |
+|-------------|---------|---------------|---------------|
+| Requirements Coverage | 100% FR/NFR covered | 90%+ covered, gaps are minor | <90% covered or critical gap |
+| Missing Requirements | 0 missing | 0 missing but assumptions made | 1+ FR/NFR missing |
+| Over-Implementation | 0 extra features | Minor convenience additions | Significant scope creep |
+
+### Code Quality Reviewer
+
+| Rubric Item | 🟢 Good | 🟡 Acceptable | 🔴 Needs Work |
+|-------------|---------|---------------|---------------|
+| Complexity | No high-complexity functions | 1-2 complex functions with justification | 3+ high-complexity functions |
+| Test Coverage | All behaviors tested, edge cases included | Core paths tested, some edges missing | Critical paths untested |
+| Error Handling | All error paths handled consistently | Most errors handled, some gaps | Missing error handling on critical paths |
+
+### Security Reviewer
+
+| Rubric Item | 🟢 Good | 🟡 Acceptable | 🔴 Needs Work |
+|-------------|---------|---------------|---------------|
+| OWASP Compliance | All applicable OWASP items pass | Minor items pending, no exploitable paths | Exploitable vulnerability found |
+| Auth/Authz Validation | All auth checks present and correct | Auth present but edge cases uncovered | Missing or bypassable auth check |
+| Input Validation Coverage | All external inputs validated | Most inputs validated, low-risk gaps | Unvalidated input on trust boundary |
+
+### Maintainability Reviewer
+
+| Rubric Item | 🟢 Good | 🟡 Acceptable | 🔴 Needs Work |
+|-------------|---------|---------------|---------------|
+| Coupling Assessment | Low coupling, clear interfaces | Moderate coupling with justification | High coupling, changes propagate widely |
+| Change Impact Scope | Changes are localized | 2-3 files affected by future changes | 4+ files affected, ripple risk |
+| Tech Debt Indicators | 0 new debt indicators | 1-2 minor indicators (TODO with ticket) | 3+ indicators or deprecated API usage |

--- a/skills/_shared/reviewers/code-quality-reviewer-prompt.md
+++ b/skills/_shared/reviewers/code-quality-reviewer-prompt.md
@@ -18,19 +18,23 @@
 3. **아키텍처**: 기존 패턴 준수, 적절한 추상화 수준
 4. **에러 핸들링**: 적절한 에러 처리, 실패 경로의 명확성, 에러 전파 일관성
 5. **DRY**: 불필요한 중복 없음, 적절한 추상화 수준
-6. **기본 보안 체크** (명백한 취약점만 — 심층 분석은 Stage 3 전담):
-   - Injection (SQL, Command, XSS) — 외부 입력이 쿼리/명령/출력에 직접 들어가는 경우
-   - 하드코딩된 시크릿/크레덴셜
-   - 안전하지 않은 설정 (debug=True, CORS * 등)
+
+## Rubric
+
+Score each item using the Code Quality Reviewer rubric from the schema:
+
+| Item | How to Assess |
+|------|--------------|
+| Complexity | Count high-complexity functions (cyclomatic complexity, deep nesting) |
+| Test Coverage | Evaluate behavior coverage: core paths, edge cases, failure paths |
+| Error Handling | Check error paths are handled consistently across all entry points |
 
 ## Issue Classification
 
-- **Critical**: 반드시 수정 (버그, 명백한 보안 취약점, 데이터 손실 위험)
+- **Critical**: 반드시 수정 (버그, 데이터 손실 위험)
 - **Important**: 수정 권장 (성능, 유지보수성, 테스트 갭)
 - **Minor**: 선택적 (스타일, 네이밍 개선)
 
-## Report Format
+## Output Format
 
-**Strengths**: [잘된 점]
-**Issues**: [Critical/Important/Minor 분류별 목록]
-**Assessment**: ✅ Approved | ❌ Requires Changes (Critical/Important 이슈 시)
+Read `_shared/patterns/review-feedback-schema.md` and follow the output template exactly. Use the Code Quality Reviewer rubric in the Score table. Report Verdict as PASS, CONDITIONAL, or FAIL per the schema criteria.

--- a/skills/_shared/reviewers/maintainability-reviewer-prompt.md
+++ b/skills/_shared/reviewers/maintainability-reviewer-prompt.md
@@ -41,31 +41,22 @@
 - 복사-붙여넣기 코드 — 추상화 기회가 명확한 중복
 - 버전 고정 없는 의존성
 
+## Rubric
+
+Score each item using the Maintainability Reviewer rubric from the schema:
+
+| Item | How to Assess |
+|------|--------------|
+| Coupling Assessment | Evaluate component dependencies and change propagation |
+| Change Impact Scope | Count files affected by future changes to this code |
+| Tech Debt Indicators | Count TODO/FIXME, deprecated APIs, copy-paste code |
+
 ## Issue Classification
 
 - **Critical**: 반드시 수정 (순환 의존, 변경 시 광범위한 파급, 폐기 예정 API 의존)
 - **Important**: 수정 권장 (높은 결합도, 테스트-구현 과결합, 가독성 저해)
 - **Minor**: 선택적 (추상화 기회, 네이밍 개선, 문서화 제안)
 
-## Report Format
+## Output Format
 
-```
-## Maintainability & Future Risk Review
-
-**Scope**: [변경 파일 목록]
-
-### Change Impact Summary
-[이 변경의 유지보수 영향 요약 — 결합도, 변경 전파 범위]
-
-### Issues
-**Critical:** [있으면 — file:line, 리스크, 영향 범위, 수정 방안]
-**Important:** [있으면]
-**Minor:** [있으면]
-
-### Tech Debt Indicators
-- [발견된 기술 부채 징후 목록]
-
-### Assessment
-**Status:** Maintainable | Issues Found
-**Reasoning:** [기술적 판단]
-```
+Read `_shared/patterns/review-feedback-schema.md` and follow the output template exactly. Use the Maintainability Reviewer rubric in the Score table. Include Change Impact analysis in the Context section. Report Verdict as PASS, CONDITIONAL, or FAIL per the schema criteria.

--- a/skills/_shared/reviewers/security-reviewer-prompt.md
+++ b/skills/_shared/reviewers/security-reviewer-prompt.md
@@ -19,6 +19,7 @@
 - **민감 데이터 노출**: 로그에 비밀번호/토큰, 평문 저장, 불필요한 데이터 반환
 - **입력 검증 부재**: 사용자 입력 미검증, 타입/범위 체크 누락, allowlist vs denylist
 - **안전하지 않은 설정**: CORS *, debug=True, CSRF 비활성, 과도한 권한
+- **기본 보안 체크** (code-quality에서 이관): Injection, 하드코딩된 시크릿/크레덴셜, 안전하지 않은 설정
 
 ### 2. 언어별 보안 주의사항
 - **Python**: `eval()`/`exec()`, `pickle` 역직렬화, subprocess `shell=True`, `yaml.load()` without SafeLoader
@@ -44,31 +45,22 @@
 - 신뢰 경계(trust boundary)를 넘는 데이터에 대한 검증 여부
 - 에러 메시지에 내부 구현 정보 노출 여부
 
+## Rubric
+
+Score each item using the Security Reviewer rubric from the schema:
+
+| Item | How to Assess |
+|------|--------------|
+| OWASP Compliance | Check applicable OWASP items against implementation |
+| Auth/Authz Validation | Verify all auth checks are present and correct |
+| Input Validation Coverage | Trace external inputs to ensure validation at trust boundaries |
+
 ## Issue Classification
 
 - **Critical**: 반드시 수정 (보안 취약점, 데이터 손실/유출 위험, 악용 가능한 논리 오류)
 - **Important**: 수정 권장 (잠재적 엣지케이스 미처리, 방어적 프로그래밍 부족)
 - **Minor**: 선택적 (보안 강화 제안, 추가 검증 권장)
 
-## Report Format
+## Output Format
 
-```
-## Security & Edge-case Review
-
-**Scope**: [변경 파일 목록]
-
-### Threat Surface
-[이 변경이 노출하는 주요 위협 영역 요약]
-
-### Issues
-**Critical:** [있으면 — file:line, 공격 벡터, 영향, 수정 방안]
-**Important:** [있으면]
-**Minor:** [있으면]
-
-### Edge Cases Checked
-- [검증한 엣지케이스 목록과 결과]
-
-### Assessment
-**Status:** Secure | Issues Found
-**Reasoning:** [기술적 판단]
-```
+Read `_shared/patterns/review-feedback-schema.md` and follow the output template exactly. Use the Security Reviewer rubric in the Score table. Include Threat Surface analysis in the Context section. Report Verdict as PASS, CONDITIONAL, or FAIL per the schema criteria.

--- a/skills/_shared/reviewers/spec-reviewer-prompt.md
+++ b/skills/_shared/reviewers/spec-reviewer-prompt.md
@@ -20,13 +20,22 @@
 2. 요청하지 않은 것이 추가되었는가? (과잉 구현 확인)
 3. 요구사항의 의도가 정확히 반영되었는가? (오해 확인)
 
-## Report Format
+## Rubric
 
-**✅ Spec Compliant** — 요구사항 전부 충족, 과잉 구현 없음
+Score each item using the Spec Compliance Reviewer rubric from the schema:
 
-또는
+| Item | How to Assess |
+|------|--------------|
+| Requirements Coverage | Count covered FR/NFR vs total |
+| Missing Requirements | Count missing FR/NFR |
+| Over-Implementation | Count features not in spec |
 
-**❌ Issues Found**
-- Missing: [누락된 요구사항] — [파일:라인]
-- Extra: [추가된 불필요 기능] — [파일:라인]
-- Misunderstood: [오해된 요구사항] — [상세 설명]
+## Issue Classification
+
+- **Critical**: 반드시 수정 (누락된 핵심 요구사항, 심각한 오해)
+- **Important**: 수정 권장 (과잉 구현, 부분적 오해)
+- **Minor**: 선택적 (사소한 해석 차이)
+
+## Output Format
+
+Read `_shared/patterns/review-feedback-schema.md` and follow the output template exactly. Use the Spec Compliance Reviewer rubric in the Score table. Report Verdict as PASS, CONDITIONAL, or FAIL per the schema criteria.

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -105,6 +105,32 @@ B) 승인, 코드 생성 진행
 
 승인 후: devflow-state에 unit 목록 기록
 
+### 1.5. SDD 모드 게이트 (Multi-unit만)
+<!-- @gate: sdd-mode -->
+<!-- @gate-option: A -> subagent-driven-development {SDD} -->
+<!-- @gate-option: B -> code-generation {인라인} -->
+
+units-generation 승인 후, unit 수를 확인하여 SDD 모드 게이트를 제시한다.
+
+**unit 1개**: 게이트 없이 인라인 모드 자동 적용 → 섹션 2로 진행.
+
+**unit 2개 이상**: SDD 모드 게이트 제시:
+```
+unit이 [N]개입니다. 컨텍스트 격리를 위해 SDD 모드를 권장합니다.
+
+A) SDD 모드 (기본) — unit별 서브에이전트로 컨텍스트 리셋
+   → aidlc-subagent-driven-development에 위임
+B) 인라인 모드 — 현재 컨텍스트에서 순차 실행
+```
+
+**A (SDD 모드) 선택 시:**
+1. Comprehensive에서 functional-design이 포함된 경우, SDD 호출 **전에** orchestrator가 unit별로 functional-design을 실행한다
+2. `aidlc-subagent-driven-development` 호출 (인라인 신호: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level]"`)
+3. SDD 모드에서는 개별 unit 게이트(code-plan 게이트, 구현 게이트)가 **비활성화** — SDD 스킬의 태스크 완료 + R1 리뷰가 품질 게이트 역할
+4. SDD 완료 후 → build-and-test(섹션 3)로 바로 진행
+
+**B (인라인 모드) 선택 시:** 기존 섹션 2 루프 그대로 실행.
+
 ### 2. code-generation (Multi-unit 핸들링)
 
 `devflow-docs/inception/units.md`에서 구현 순서를 읽는다.

--- a/skills/aidlc-requesting-code-review/SKILL.md
+++ b/skills/aidlc-requesting-code-review/SKILL.md
@@ -86,39 +86,39 @@ spec/plan 경로가 제공된 경우에만 실행. 미제공 시 Stage 2로 바�
 
 1. `_shared/reviewers/spec-reviewer-prompt.md` 읽기
 2. 서브에이전트 dispatch — `{project-root}` + 리뷰 대상 + spec/plan 경로 전달
-3. 결과 확인:
-   - ✅ Spec compliant → Stage 2로
-   - ❌ Issues Found → 수정 후 re-dispatch (conventions 리뷰 루프 규약: 최대 5회, 초과 시 사용자 escalate)
-   - Recommendations만 → Stage 2로 (수정 권장)
+3. 결과 확인 (Verdict 기준):
+   - PASS → Stage 2로
+   - FAIL → 수정 후 re-dispatch (conventions 리뷰 루프 규약: 최대 5회, 초과 시 사용자 escalate)
+   - CONDITIONAL → Stage 2로 (수정 권장)
 
 #### Stage 2 — Code Quality
 
 1. `_shared/reviewers/code-quality-reviewer-prompt.md` 읽기
 2. 서브에이전트 dispatch — `{project-root}` + 리뷰 대상 전달
-3. 결과 확인:
-   - ✅ Approved → Stage 3으로
-   - ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
-   - Recommendations만 → 루프 종료, Stage 3으로 (수정 권장)
+3. 결과 확인 (Verdict 기준):
+   - PASS → Stage 3으로
+   - FAIL → 수정 후 re-dispatch (최대 5회)
+   - CONDITIONAL → Stage 3으로 (수정 권장)
 
 #### Stage 3 — Security/Edge-case (Standard 이상)
 
 depth가 **Standard 이상**이면 실행. Minimal은 스킵.
 
 1. `_shared/reviewers/security-reviewer-prompt.md` 서브에이전트 dispatch (`{project-root}` 포함)
-2. 결과 확인:
-   - ✅ 통과 → Stage 4 또는 결과 반환으로
-   - ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
-   - Recommendations만 → 루프 종료 (수정 권장)
+2. 결과 확인 (Verdict 기준):
+   - PASS → Stage 4 또는 결과 반환으로
+   - FAIL → 수정 후 re-dispatch (최대 5회)
+   - CONDITIONAL → 루프 종료 (수정 권장)
 
 #### Stage 4 — Maintainability (Comprehensive만)
 
 depth가 **Comprehensive**인 경우에만 실행. Standard 이하는 스킵하고 결과 반환으로 진행.
 
 1. `_shared/reviewers/maintainability-reviewer-prompt.md` 서브에이전트 dispatch (`{project-root}` 포함)
-2. 결과 확인:
-   - ✅ 통과 → 결과 반환으로
-   - ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
-   - Recommendations만 → 루프 종료 (수정 권장)
+2. 결과 확인 (Verdict 기준):
+   - PASS → 결과 반환으로
+   - FAIL → 수정 후 re-dispatch (최대 5회)
+   - CONDITIONAL → 루프 종료 (수정 권장)
 
 > **Comprehensive에서의 병렬화**: Stage 3과 4가 모두 실행되는 Comprehensive에서는 두 리뷰어를 **병렬 dispatch** 가능 (독립적 관점, 상호 의존 없음).
 
@@ -148,7 +148,7 @@ R2 또는 Ra 선택 시, 4-stage 관점을 외부 AI와 함께 실행한다.
 6. **synthesis 결과를 사용자에게 표시 + 승인 대기**:
    ```
    [Council Code Review 결과]
-   Gate Decision: [PASS|CONDITIONAL|FAIL]
+   Verdict: [PASS|CONDITIONAL|FAIL]
    Rationale: [판정 근거]
    Action Items: [수정 항목]
 
@@ -176,11 +176,11 @@ R3 선택 시, 리뷰어들이 Agent Teams로 팀을 구성하여 소통 기반 
    - 리뷰어들이 병렬로 리뷰 수행 + SendMessage로 발견 사항 공유
    - 팀 리드가 모든 결과 수신 후 종합 (결과 반환 형식으로 변환)
    - TeamDelete로 팀 정리
-   - **이슈 수정 루프**: Needs fixes 판정 시 수정 후 팀 재생성하여 re-review (최대 5회, 초과 시 사용자 escalate — R1과 동일 제한)
+   - **이슈 수정 루프**: FAIL 또는 CONDITIONAL 판정 시 수정 후 팀 재생성하여 re-review (최대 5회, 초과 시 사용자 escalate — R1과 동일 제한)
 4. **종합 결과를 사용자에게 표시 + 승인 대기**:
    ```
    [Agent Teams Code Review 결과]
-   Assessment: [Ready to merge | Needs fixes]
+   Verdict: [PASS | CONDITIONAL | FAIL]
    Cross-cutting Issues: [리뷰어 간 소통에서 도출된 교차 이슈]
    Issues: [분류별 목록]
 
@@ -198,16 +198,20 @@ R3 선택 시, 리뷰어들이 Agent Teams로 팀을 구성하여 소통 기반 
 
 ### 결과 반환
 
+각 Stage의 리뷰어는 `_shared/patterns/review-feedback-schema.md`의 출력 포맷을 따른다. Synthesis는 개별 Verdict를 worst-of 로직으로 집계한다.
+
 ```
 ## Code Review 결과
-- Stage 1 (Spec Compliance): ✅ 통과 | ❌ 이슈 | ⏭ 스킵 (spec 미제공)
-- Stage 2 (Code Quality): ✅ 통과 | ❌ 이슈
-- Stage 3 (Security/Edge-case): ✅ 통과 | ❌ 이슈 | ⏭ 스킵 (Minimal)
-- Stage 4 (Maintainability): ✅ 통과 | ❌ 이슈 | ⏭ 스킵 (Standard 이하)
-- Assessment: Ready to merge | Needs fixes
-- Issues: [있으면 목록]
-- Recommendations: [있으면 목록]
+- Stage 1 (Spec Compliance): PASS | CONDITIONAL | FAIL | ⏭ 스킵 (spec 미제공)
+- Stage 2 (Code Quality): PASS | CONDITIONAL | FAIL
+- Stage 3 (Security/Edge-case): PASS | CONDITIONAL | FAIL | ⏭ 스킵 (Minimal)
+- Stage 4 (Maintainability): PASS | CONDITIONAL | FAIL | ⏭ 스킵 (Standard 이하)
+- Verdict: PASS | CONDITIONAL | FAIL (worst-of across all stages)
+- Issues: [있으면 — severity + file:line 테이블]
+- Score: [루브릭 항목별 🟢/🟡/🔴 집계]
 ```
+
+**Verdict 집계 (worst-of)**: 어느 Stage든 FAIL이면 전체 FAIL. FAIL 없이 CONDITIONAL 있으면 전체 CONDITIONAL. 모두 PASS면 전체 PASS.
 
 ---
 
@@ -256,9 +260,9 @@ SDD에서 호출 시, SDD가 리뷰 대상(변경 파일)과 spec/plan 경로를
 
 [depth: Standard, spec 미제공]
 → Stage 1 스킵 (spec 없음)
-→ Stage 2: code-quality-reviewer dispatch → ✅ Approved
-→ Stage 3: security-reviewer dispatch → ✅ Secure
-→ 결과: ✅ Ready to merge / Recommendations 2건
+→ Stage 2: code-quality-reviewer dispatch → PASS
+→ Stage 3: security-reviewer dispatch → PASS
+→ Verdict: PASS / Recommendations 2건
 ```
 
 ### Example 2: SDD에서 자동 호출 (Standard)
@@ -269,24 +273,24 @@ SDD: 태스크 3 완료, requesting-code-review 호출
   spec: docs/plans/auth-plan.md Task 3
   depth: Standard
 
-→ Stage 1: spec-reviewer → ❌ Issues 1건 (누락된 에러 핸들링)
-→ 수정 후 재리뷰 → ✅ Spec compliant
-→ Stage 2: code-quality-reviewer → ✅ Approved
-→ Stage 3: security-reviewer → ✅ Secure
-→ 결과: Ready to merge
+→ Stage 1: spec-reviewer → FAIL (누락된 에러 핸들링)
+→ 수정 후 재리뷰 → PASS
+→ Stage 2: code-quality-reviewer → PASS
+→ Stage 3: security-reviewer → PASS
+→ Verdict: PASS
 ```
 
 ### Example 3: Comprehensive 리뷰
 
 ```
 [depth: Comprehensive, spec 제공]
-→ Stage 1: spec-reviewer → ✅ Spec compliant
-→ Stage 2: code-quality-reviewer → ✅ Approved
+→ Stage 1: spec-reviewer → PASS
+→ Stage 2: code-quality-reviewer → PASS
 → Stage 3 + 4 병렬 dispatch:
-  → security-reviewer → ❌ Issues 1건 (SQL injection 위험)
-  → maintainability-reviewer → ✅ Maintainable
-→ 수정 후 Stage 3 재리뷰 → ✅ Secure
-→ 결과: Ready to merge / Recommendations 1건
+  → security-reviewer → FAIL (SQL injection 위험)
+  → maintainability-reviewer → PASS
+→ 수정 후 Stage 3 재리뷰 → PASS
+→ Verdict: PASS / Recommendations 1건
 ```
 
 ### Example 4: Agent Teams 협업 리뷰 (Standard)
@@ -305,7 +309,7 @@ SDD: 태스크 3 완료, requesting-code-review 호출
   - Cross-cutting: 입력 검증 누락이 품질+보안 모두에 영향
   - Issues: Important 2건 (중복 제거됨, 원래 3건)
 → TeamDelete
-→ 결과: Needs fixes / Important 2건
+→ Verdict: CONDITIONAL / Important 2건
 ```
 
 ---

--- a/skills/aidlc-subagent-driven-development/SKILL.md
+++ b/skills/aidlc-subagent-driven-development/SKILL.md
@@ -23,12 +23,31 @@ metadata:
 - 태스크가 대부분 독립적일 때
 - 서브에이전트 지원 환경 (Claude Code 등)
 
+## 입력 모드
+
+### 모드 1: 계획 파일 기반 (기본)
+사용자가 직접 호출하거나 `aidlc-writing-plans`에서 호출 시. 계획 파일에서 태스크 목록을 읽는다.
+
+### 모드 2: Orchestrator 위임 모드 (units.md 기반)
+`aidlc-construction-orchestrator`가 SDD 모드로 호출 시.
+
+**호출 신호**: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level]"`
+
+이 신호를 받으면:
+1. units.md에서 unit 목록을 읽고, 각 unit을 태스크로 변환
+2. session-summary.md에서 unit 완료 상태 + units.md의 인터페이스 정의만 참조
+3. **컨텍스트 격리**: 각 unit 서브에이전트에 이전 unit의 code-plan, 구현 코드, 변경 파일 목록 전달 금지
+4. **finishing-branch 비활성화**: orchestrator 위임 모드에서는 `aidlc-finishing-a-development-branch` 호출을 스킵. orchestrator가 후속 처리
+5. **최종 코드 리뷰 비활성화**: orchestrator가 build-and-test를 별도 실행하므로 SDD 내 최종 리뷰 스킵
+6. 모든 unit의 R1 리뷰 통과 → orchestrator에 제어 반환
+
 ## 프로세스 (태스크 반복)
 
 > **순차 실행 필수**: Task 1의 리뷰까지 완전 완료 → Task 2 시작. 태스크 간 병렬 실행 금지.
 
 ### 1. 계획 읽기
-- 계획 파일에서 전체 태스크 텍스트 + 컨텍스트 추출
+- **모드 1**: 계획 파일에서 전체 태스크 텍스트 + 컨텍스트 추출
+- **모드 2**: units.md에서 unit 목록 추출. 각 unit의 구현 범위를 태스크로 변환
 - 태스크 목록 생성
 
 ### 2. 구현 서브에이전트 디스패치

--- a/tests/scenarios/construction-comprehensive.yaml
+++ b/tests/scenarios/construction-comprehensive.yaml
@@ -1,12 +1,10 @@
-name: "Construction — Comprehensive with functional design"
+name: "Construction — Comprehensive with functional design (SDD mode)"
 orchestrator: aidlc-construction-orchestrator
 inputs:
   complexity: Comprehensive
   choices:
     units-generation: B
-    functional-design: B
-    code-plan: B
-    code-generation-result: B
+    sdd-mode: A
     build-and-test-result: A
 expect:
   stage_path:

--- a/tests/scenarios/construction-multi-unit.yaml
+++ b/tests/scenarios/construction-multi-unit.yaml
@@ -1,11 +1,10 @@
-name: "Construction — Multi unit standard path"
+name: "Construction — Multi unit standard path (SDD mode)"
 orchestrator: aidlc-construction-orchestrator
 inputs:
   complexity: Standard
   choices:
     units-generation: B
-    code-plan: B
-    code-generation-result: B
+    sdd-mode: A
     build-and-test-result: A
 expect:
   stage_path:

--- a/tests/test_quantitative_rubric.py
+++ b/tests/test_quantitative_rubric.py
@@ -1,0 +1,301 @@
+"""Quantitative Rubric and Structured Feedback validation tests.
+
+Validates that:
+- review-feedback-schema.md exists with required sections
+- 4 code reviewer prompts reference the schema
+- requesting-code-review uses Verdict system (PASS/CONDITIONAL/FAIL)
+- construction-orchestrator has SDD mode gate for multi-unit
+- SDD skill supports units.md input + orchestrator delegation mode
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+
+def read_skill(name: str) -> str:
+    """Read a SKILL.md file content."""
+    path = SKILLS_DIR / name / "SKILL.md"
+    return path.read_text(encoding="utf-8")
+
+
+def read_shared(relative_path: str) -> str:
+    """Read a file from _shared directory."""
+    path = SKILLS_DIR / "_shared" / relative_path
+    return path.read_text(encoding="utf-8")
+
+
+# --- Step 1: review-feedback-schema.md existence and required sections ---
+
+
+class TestReviewFeedbackSchema:
+    """review-feedback-schema.md must exist with all required sections."""
+
+    def test_schema_file_exists(self):
+        path = SKILLS_DIR / "_shared" / "patterns" / "review-feedback-schema.md"
+        assert path.exists(), "review-feedback-schema.md must exist in _shared/patterns/"
+
+    def test_schema_has_verdict_criteria(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "PASS" in content and "CONDITIONAL" in content and "FAIL" in content, \
+            "Schema must define PASS/CONDITIONAL/FAIL verdict criteria"
+
+    def test_schema_has_issues_table_format(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "Severity" in content and "File:Line" in content, \
+            "Schema must define Issues table format with Severity and File:Line columns"
+
+    def test_schema_has_score_table(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "🟢" in content and "🟡" in content and "🔴" in content, \
+            "Schema must define 3-level score (🟢/🟡/🔴)"
+
+    def test_schema_has_context_section(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "Context" in content, \
+            "Schema must define Context section for domain-specific summaries"
+
+    def test_schema_has_pass_criteria(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "Pass Criteria" in content, \
+            "Schema must define Pass Criteria checklist format"
+
+    def test_schema_has_rubric_for_all_reviewers(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        for reviewer in ["spec", "quality", "security", "maintainability"]:
+            assert reviewer.lower() in content.lower(), \
+                f"Schema must include rubric items for {reviewer} reviewer"
+
+    def test_schema_has_scoring_guidelines(self):
+        """Each rubric item must have scoring guidelines (what is Good vs Needs Work)."""
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert re.search(r"Good|Acceptable|Needs Work", content), \
+            "Schema must include scoring guidelines for rubric items"
+
+
+# --- Step 2: 4 code reviewer prompts reference the schema ---
+
+REVIEWER_PROMPTS = [
+    "reviewers/spec-reviewer-prompt.md",
+    "reviewers/code-quality-reviewer-prompt.md",
+    "reviewers/security-reviewer-prompt.md",
+    "reviewers/maintainability-reviewer-prompt.md",
+]
+
+
+class TestReviewerSchemaReference:
+    """All 4 code reviewer prompts must reference review-feedback-schema.md."""
+
+    @pytest.mark.parametrize("prompt_path", REVIEWER_PROMPTS)
+    def test_reviewer_references_schema(self, prompt_path):
+        content = read_shared(prompt_path)
+        assert "review-feedback-schema.md" in content, \
+            f"{prompt_path} must reference review-feedback-schema.md"
+
+    @pytest.mark.parametrize("prompt_path", REVIEWER_PROMPTS)
+    def test_reviewer_has_verdict_output(self, prompt_path):
+        content = read_shared(prompt_path)
+        assert "Verdict" in content, \
+            f"{prompt_path} must use Verdict in output format"
+
+    @pytest.mark.parametrize("prompt_path", REVIEWER_PROMPTS)
+    def test_reviewer_has_rubric_items(self, prompt_path):
+        content = read_shared(prompt_path)
+        assert re.search(r"🟢|🟡|🔴|Rubric|Score", content, re.IGNORECASE), \
+            f"{prompt_path} must include rubric scoring items"
+
+    def test_quality_reviewer_no_basic_security_check(self):
+        """code-quality-reviewer must NOT have basic security check (moved to security)."""
+        content = read_shared("reviewers/code-quality-reviewer-prompt.md")
+        assert "기본 보안 체크" not in content, \
+            "Basic security check must be removed from quality reviewer (moved to security)"
+
+    def test_security_reviewer_has_context_section(self):
+        """security-reviewer must have Context section (moved from Threat Surface)."""
+        content = read_shared("reviewers/security-reviewer-prompt.md")
+        # Should NOT have standalone Threat Surface as a report section
+        # Should reference Context section from schema
+        assert "review-feedback-schema.md" in content
+
+    def test_maintainability_reviewer_has_context_section(self):
+        """maintainability-reviewer must have Context section (moved from Change Impact Summary)."""
+        content = read_shared("reviewers/maintainability-reviewer-prompt.md")
+        assert "review-feedback-schema.md" in content
+
+
+# --- Step 3: requesting-code-review Verdict system ---
+
+
+class TestRequestingCodeReviewVerdict:
+    """requesting-code-review must use Verdict system."""
+
+    def test_has_verdict_in_result_format(self):
+        content = read_skill("aidlc-requesting-code-review")
+        assert "Verdict" in content, \
+            "requesting-code-review must use Verdict in result format"
+
+    def test_has_pass_conditional_fail(self):
+        content = read_skill("aidlc-requesting-code-review")
+        assert "PASS" in content and "CONDITIONAL" in content and "FAIL" in content, \
+            "requesting-code-review must define PASS/CONDITIONAL/FAIL verdicts"
+
+    def test_references_schema(self):
+        content = read_skill("aidlc-requesting-code-review")
+        assert "review-feedback-schema.md" in content, \
+            "requesting-code-review must reference review-feedback-schema.md"
+
+    def test_verdict_replaces_assessment(self):
+        """Verdict should replace old 'Ready to merge | Needs fixes' assessment."""
+        content = read_skill("aidlc-requesting-code-review")
+        # The result return section should use Verdict, not the old Assessment
+        assert re.search(r"Verdict.*PASS.*CONDITIONAL.*FAIL", content, re.DOTALL), \
+            "Result return must use Verdict system"
+
+
+# --- Step 4: construction-orchestrator SDD mode gate ---
+
+
+class TestConstructionOrchestratorSDDGate:
+    """construction-orchestrator must have SDD mode gate for multi-unit."""
+
+    def test_has_sdd_mode_gate(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"sdd.*mode|SDD.*모드", content, re.IGNORECASE), \
+            "construction-orchestrator must have SDD mode gate"
+
+    def test_has_sdd_gate_meta_tag(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert "sdd-mode" in content, \
+            "construction-orchestrator must have @gate for sdd-mode"
+
+    def test_sdd_gate_has_options(self):
+        """SDD gate must have A (SDD) and B (inline) options."""
+        content = read_skill("aidlc-construction-orchestrator")
+        has_sdd_option = re.search(r"A\).*SDD", content)
+        has_inline_option = re.search(r"B\).*인라인|B\).*inline", content, re.IGNORECASE)
+        assert has_sdd_option and has_inline_option, \
+            "SDD gate must offer A) SDD and B) inline options"
+
+    def test_sdd_references_subagent_driven_development(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert "subagent-driven-development" in content, \
+            "SDD mode must reference aidlc-subagent-driven-development skill"
+
+    def test_sdd_gate_positioned_after_units(self):
+        """SDD gate must come after units-generation gate."""
+        content = read_skill("aidlc-construction-orchestrator")
+        units_pos = content.find("units-generation")
+        sdd_pos = content.find("sdd-mode")
+        assert units_pos > 0 and sdd_pos > 0 and sdd_pos > units_pos, \
+            "SDD gate must be positioned after units-generation gate"
+
+
+# --- Step 5: SDD skill units.md input mode ---
+
+
+class TestSDDUnitsInputMode:
+    """SDD skill must support units.md input and orchestrator delegation mode."""
+
+    def test_sdd_has_units_input_mode(self):
+        content = read_skill("aidlc-subagent-driven-development")
+        assert "units.md" in content, \
+            "SDD must support units.md as input source"
+
+    def test_sdd_has_orchestrator_delegation_mode(self):
+        content = read_skill("aidlc-subagent-driven-development")
+        assert re.search(r"orchestrator.*위임|delegation.*mode|위임.*모드", content, re.IGNORECASE), \
+            "SDD must have orchestrator delegation mode"
+
+    def test_sdd_disables_finishing_branch_in_delegation(self):
+        content = read_skill("aidlc-subagent-driven-development")
+        assert re.search(r"finishing.*비활성|finishing.*disable|finishing.*skip", content, re.IGNORECASE), \
+            "SDD must disable finishing-branch in delegation mode"
+
+    def test_sdd_has_signal_interface(self):
+        """SDD must parse the orchestrator signal format."""
+        content = read_skill("aidlc-subagent-driven-development")
+        assert "SDD:" in content and "units=" in content, \
+            "SDD must parse 'SDD: units=[path]' signal format"
+
+    def test_sdd_has_context_isolation(self):
+        """SDD must enforce context isolation between units."""
+        content = read_skill("aidlc-subagent-driven-development")
+        assert re.search(r"격리|isolation|전달.*제한|전달.*금지", content, re.IGNORECASE), \
+            "SDD must enforce context isolation between units"
+
+
+# --- Third-party review: additional tests ---
+
+
+class TestVerdictCriteriaMapping:
+    """Verify precise verdict determination rules from FR-4."""
+
+    def test_schema_verdict_pass_criteria(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert re.search(r"PASS.*0.*Critical.*0.*🔴", content, re.DOTALL), \
+            "Schema must define PASS = 0 Critical + 0 🔴"
+
+    def test_schema_verdict_fail_criteria(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert re.search(r"FAIL.*1\+.*Critical", content, re.DOTALL), \
+            "Schema must define FAIL = 1+ Critical"
+
+    def test_worst_of_aggregation(self):
+        content = read_skill("aidlc-requesting-code-review")
+        assert "worst-of" in content, \
+            "requesting-code-review must define worst-of verdict aggregation"
+
+
+class TestSDDSignalAndGateDetails:
+    """Verify SDD signal format and gate details from FR-1/FR-2."""
+
+    def test_orchestrator_sdd_signal_format(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert "SDD:" in content and "units=" in content and "summary=" in content, \
+            "Orchestrator must define SDD signal format with units= and summary="
+
+    def test_single_unit_auto_inline(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"unit.*1.*게이트.*없이.*인라인|unit.*1.*인라인.*자동", content, re.IGNORECASE), \
+            "Single unit must skip SDD gate and auto-apply inline mode"
+
+    def test_sdd_disables_unit_gates(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"게이트.*비활성|gate.*disable", content, re.IGNORECASE), \
+            "SDD mode must disable code-plan and implementation gates"
+
+    def test_sdd_functional_design_before_sdd(self):
+        content = read_skill("aidlc-construction-orchestrator")
+        assert re.search(r"functional-design.*SDD.*전|SDD.*호출.*전.*functional-design", content, re.DOTALL), \
+            "Functional design must be executed before SDD handoff"
+
+    def test_single_unit_scenario_has_no_sdd_gate(self):
+        scenario = Path(__file__).parent / "scenarios" / "construction-single-unit.yaml"
+        content = scenario.read_text()
+        assert "sdd-mode" not in content, \
+            "Single-unit scenario must not include sdd-mode gate"
+
+
+class TestSchemaCompleteness:
+    """Verify schema preserves both severity and rubric systems."""
+
+    def test_schema_has_context_heading_in_template(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        assert "### Context" in content, \
+            "Schema output template must include ### Context heading"
+
+    def test_schema_preserves_severity_alongside_rubric(self):
+        content = read_shared("patterns/review-feedback-schema.md")
+        has_severity = "Critical" in content and "Important" in content and "Minor" in content
+        has_rubric = "🟢" in content and "🟡" in content and "🔴" in content
+        assert has_severity and has_rubric, \
+            "Schema must preserve Critical/Important/Minor alongside 🟢/🟡/🔴 rubric"
+
+    @pytest.mark.parametrize("prompt_path", REVIEWER_PROMPTS)
+    def test_reviewer_has_read_instruction(self, prompt_path):
+        content = read_shared(prompt_path)
+        assert re.search(r"Read|읽", content) and "review-feedback-schema.md" in content, \
+            f"{prompt_path} must instruct reading review-feedback-schema.md"


### PR DESCRIPTION
Closes #89
Closes #90

## Summary
- **BL-049 SDD 기본화**: multi-unit(2+) 시 SDD를 기본 실행 모드로 승격. construction-orchestrator에 SDD 모드 게이트 추가 + SDD 스킬에 units.md 기반 입력/orchestrator 위임 모드 추가
- **BL-050 정량 루브릭**: review-feedback-schema.md 신규 생성 + 4개 코드 리뷰어에 도메인별 루브릭 추가 + requesting-code-review Verdict 체계(PASS/CONDITIONAL/FAIL) 도입
- 51개 신규 테스트 (188 total), 제3자 테스트 리뷰 반영

## Test plan
- [x] `uv run pytest -v` — 188 passed, 2 known failures (reverse-engineering 외부 참조, 이번 변경 무관)
- [x] review-feedback-schema.md 존재 + 필수 섹션 검증 — 8 passed
- [x] 4개 리뷰어 프롬프트 schema 참조 확인 — 15 passed
- [x] construction-orchestrator SDD 모드 게이트 확인 (multi-unit 시나리오) — 5 passed
- [x] SDD 스킬 units.md 입력 + orchestrator 위임 모드 확인 — 5 passed
- [x] requesting-code-review Verdict 체계 확인 — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)