### PR TITLE
feat: graph_validator 외부 참조 수정 + complexity 간소화 + Pre-Planning 안내

### DIFF
--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -109,13 +109,10 @@ B 선택 시: reverse-engineering 스킬을 호출한다. 완료 후 산출물(`
 workspace-detection 결과를 기반으로 복잡도를 선언.
 
 ```
-이 작업의 복잡도를 **[Minimal/Standard/Comprehensive]**로 판단했습니다.
-이유: [한 줄 이유]
+복잡도: **[Minimal/Standard/Comprehensive]** — [한 줄 이유]
 
-다르게 조정하시겠습니까?
-
-A) 조정 요청 → 사용자 입력 받아 반영
-B) 승인 → devflow-state의 ## Complexity 업데이트 → requirements-analysis 호출
+A) 조정 요청
+B) 승인
 ```
 
 Complexity 값을 requirements-analysis 호출 시 인라인으로 전달: `"Complexity: [level]"`
@@ -172,9 +169,13 @@ requirements-analysis 게이트 통과 후, workflow-planning 호출 전에 실�
 Pre-Planning은 INCEPTION 내 스테이지 그룹명이며, workflow-plan.md의 `### PRE-PLANNING` 섹션에 결과가 기록된다.
 Minimal/Comprehensive는 자동 분기, Standard만 사용자 게이트.
 
-**Minimal complexity**: 자동 스킵 — workflow-planning으로 직행.
+**Minimal complexity**: 자동 스킵. 사용자에게 안내 후 workflow-planning으로 직행:
 
-**Comprehensive complexity**: 자동 포함 — User-Stories 게이트로 진행.
+> Minimal complexity — Pre-Planning(User Stories, NFR) 자동 스킵 → 워크플로우 계획으로 진행합니다.
+
+**Comprehensive complexity**: 자동 포함. 사용자에게 안내 후 User-Stories 게이트로 진행:
+
+> Comprehensive complexity — Pre-Planning(User Stories + NFR) 자동 포함 → User Stories 작성을 시작합니다.
 
 **Standard complexity**: 3-option 게이트 제시
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -9,8 +9,15 @@ making the update point explicit and reducing missed-update risk.
 # Update this set when adding new logical actions to orchestrator SKILL.md files.
 LOGICAL_ACTIONS = {
     "next-unit",
-    "branch-name-confirm",
+    "worktree-create",
     "inception-routing",
     "code-generation-plan",
     "code-generation-generate",
+}
+
+# External plugin references: gate-option targets that point to skills
+# from external plugins (not part of this plugin's skills/ directory).
+# Update this set when adding new external plugin references to orchestrator SKILL.md files.
+EXTERNAL_PLUGIN_REFS = {
+    "reverse-engineering",
 }

--- a/tests/test_graph_validator.py
+++ b/tests/test_graph_validator.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from constants import LOGICAL_ACTIONS
+from constants import EXTERNAL_PLUGIN_REFS, LOGICAL_ACTIONS
 
 SKILLS_DIR = Path(__file__).parent.parent / "skills"
 
@@ -52,7 +52,9 @@ def is_external_ref(target: str) -> bool:
         return True
     if target.startswith("CONSTRUCTION") or target.startswith("INCEPTION"):
         return True
-    return target in LOGICAL_ACTIONS
+    if target in LOGICAL_ACTIONS:
+        return True
+    return target in EXTERNAL_PLUGIN_REFS
 
 
 def skill_exists(name: str) -> bool:


### PR DESCRIPTION
Closes #122
Closes #107
refs #117

## Summary

- **BL-076**: `EXTERNAL_PLUGIN_REFS`에 `reverse-engineering` 등록, `LOGICAL_ACTIONS`에 `worktree-create` 추가 + `branch-name-confirm` 제거(gate ID와 중복). graph_validator 2건 실패 해소
- **BL-072**: complexity-declaration 게이트 텍스트 2줄로 간소화 (게이트 구조 유지)
- **BL-062**: Minimal/Comprehensive 자동 분기 시 안내 메시지 추가

## Test plan

- [x] graph_validator 10 passed (기존 2건 실패 해소)
- [x] 전체 테스트 269 passed, 0 failed
- [ ] complexity 게이트 간소화된 텍스트 확인 (다음 devflow 세션에서 검증)
- [ ] Pre-Planning 자동 분기 안내 메시지 확인 (다음 devflow 세션에서 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)