### PR TITLE
feat: 백로그 관리 체계 재설계 (BL-078)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 node_modules/
 .claude/
 .private-journal/
-devflow-docs/
+devflow-docs/*
+!devflow-docs/backlog.md
 __pycache__/
 .venv/
 .python-version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,24 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
 
 ---
 
-## 백로그-GitHub 이슈 연동 (필수)
+## 백로그 관리
 
-### 백로그 등록 시
-- `memory/backlog_aidlc.md`에 항목 추가
+### 백로그 파일
+- 위치: `devflow-docs/backlog.md`
+- 구조: Next (3-5건) / Open / Someday
+- Done 항목은 파일에서 제거 (git history로 추적)
+
+### GitHub 이슈 연동
+<!-- github-issues: enabled -->
+> 아래 규칙은 `github-issues: enabled`일 때만 적용한다.
+> disabled일 때는 `devflow-docs/backlog.md` 파일 기반으로만 운영한다.
+
+**백로그 등록 시:**
+- `devflow-docs/backlog.md`에 항목 추가
 - GitHub 이슈를 `enhancement` 라벨로 동시 생성 (`bluejayA/aidlc-devflow`)
 - 백로그에 이슈 번호와 링크 기록
 
-### 백로그 구현 시
+**백로그 구현 시:**
 백로그 항목을 구현하여 커밋할 때, 연결된 GitHub 이슈와 반드시 연동한다.
 
 1. **커밋 메시지에 이슈 번호 포함**
@@ -43,5 +53,5 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
    - 구현 시작 시: 간략한 접근 방식 코멘트
    - 커밋 완료 시: 변경 내용 요약 + 커밋 해시 코멘트
 
-3. **백로그 파일 상태 동기화**
-   - 구현 완료 시 `backlog_aidlc.md`의 상태를 `Done`으로 변경
+3. **백로그 파일 정리**
+   - 구현 완료 시 `devflow-docs/backlog.md`에서 해당 항목 제거

--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -1,0 +1,48 @@
+# Backlog
+
+> **완료 항목 조회 방법:**
+> - GitHub: [`is:issue is:closed`](https://github.com/bluejayA/aidlc-devflow/issues?q=is%3Aissue+is%3Aclosed) 필터
+> - Claude: "완료된 백로그 항목 보여줘" 요청 (git history 검색)
+> - Done/Closed 항목은 git history에 보존되어 있습니다.
+
+---
+
+## Next
+
+(현재 비어 있음 — Open에서 승격 필요)
+
+---
+
+## Open
+
+- **BL-042**: 행동 테스트 계층 (Layer 2) — LLM 기반 스킬 동작 검증 [P2] [#61](https://github.com/bluejayA/aidlc-devflow/issues/61)
+- **BL-044**: Multi-Unit Construction Agent Teams — 독립 유닛 병렬 구현 + 인터페이스 조율 [P2] [#70](https://github.com/bluejayA/aidlc-devflow/issues/70)
+- **BL-045**: dispatching-parallel-agents Agent Teams 강화 — 실행 중 충돌 감지/조율 [P2] [#71](https://github.com/bluejayA/aidlc-devflow/issues/71)
+- **BL-031**: deployment-prep 독립 스킬 — Dockerfile + k8s manifest 생성 (MVP) [P2] [#41](https://github.com/bluejayA/aidlc-devflow/issues/41)
+- **BL-052**: Playwright E2E 자동 검증 + 평가기 비대칭 도구 설계 [P2] [#92](https://github.com/bluejayA/aidlc-devflow/issues/92)
+- **BL-063**: 세션 재개 재검증 최대 횟수 제한 [P2] [#108](https://github.com/bluejayA/aidlc-devflow/issues/108)
+- **BL-064**: S 게이트 사용자 안내 강화 [P2] [#109](https://github.com/bluejayA/aidlc-devflow/issues/109)
+- **BL-065**: SDD 모드 functional-design 전달 문서화 [P2] [#110](https://github.com/bluejayA/aidlc-devflow/issues/110)
+- **BL-066**: NFR 모드 게이트 소유권 명확화 [P2] [#111](https://github.com/bluejayA/aidlc-devflow/issues/111)
+- **BL-077**: NFR 게이트 통합 — nfr-requirements-mode 삭제 + 스킬 내부 모드 위임 [P2] [#125](https://github.com/bluejayA/aidlc-devflow/issues/125)
+- **BL-074**: 오류 복구 경로 정의 — tech-stack 카탈로그 부재 등 폴백 [P2] [#119](https://github.com/bluejayA/aidlc-devflow/issues/119)
+- **BL-075**: devflow-state 상태 전환 문서화 [P2] [#120](https://github.com/bluejayA/aidlc-devflow/issues/120)
+
+---
+
+## Someday
+
+- **BL-021**: GitHub Flow 연동 — 이슈 생성 + 스테이지별 코멘트 + PR/머지 자동화 [P3] [#25](https://github.com/bluejayA/aidlc-devflow/issues/25)
+- **BL-053**: audit 기반 하네스 최적화 + 비용-품질 메트릭 [P3] [#93](https://github.com/bluejayA/aidlc-devflow/issues/93)
+- **BL-054**: 모델별 게이트 프로파일 — 동적 하네스 단순화 [P3] [#94](https://github.com/bluejayA/aidlc-devflow/issues/94)
+- **BL-055**: 리뷰 ROI 자동화 — risk score 기반 리뷰 강도 동적 조절 [P3] [#95](https://github.com/bluejayA/aidlc-devflow/issues/95)
+- **BL-057**: Knowledge Compounding Option B — workflow-planning 솔루션 선검색 [P3] [#97](https://github.com/bluejayA/aidlc-devflow/issues/97)
+- **BL-058**: Self-Healing × Knowledge Compounding 통합 — 경험 기반 자동 수정 [P3] [#98](https://github.com/bluejayA/aidlc-devflow/issues/98)
+- **BL-017**: infrastructure-design 스킬 [P3] [#37](https://github.com/bluejayA/aidlc-devflow/issues/37)
+- **BL-019**: 장기 컨셉 — C4 Model, operations phase [P3] [#39](https://github.com/bluejayA/aidlc-devflow/issues/39)
+- **BL-067**: NFR 기본값 테이블 정의 [P3] [#112](https://github.com/bluejayA/aidlc-devflow/issues/112)
+- **BL-068**: units 위상 정렬 검증 게이트 [P3] [#113](https://github.com/bluejayA/aidlc-devflow/issues/113)
+- **BL-069**: auto-fix 에러 분류 정교화 [P3] [#114](https://github.com/bluejayA/aidlc-devflow/issues/114)
+- **BL-070**: 디버깅 루프 소프트 리밋 [P3] [#115](https://github.com/bluejayA/aidlc-devflow/issues/115)
+- **BL-071**: workflow-planning 다이어그램 선택 접근법 반영 [P3] [#116](https://github.com/bluejayA/aidlc-devflow/issues/116)
+- **BL-073**: 컨텍스트 누적 최적화 — 스테이지별 점진 로딩 [P3] [#118](https://github.com/bluejayA/aidlc-devflow/issues/118)

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -91,7 +91,7 @@ AI-DLC 방법론을 오케스트레이터 중심 아키텍처로 구현한 Claud
 2. **TDD Iron Law**: 실패 테스트 없이 프로덕션 코드 작성 금지
 3. **증거 우선**: 완료 주장 전 반드시 검증 실행
 4. **정합성 체크**: 스킬 수정 시 `docs/guide/consistency-checklist.md` 확인
-5. **백로그-GitHub 연동**: 커밋 시 `refs #N` / `closes #N` + 이슈 코멘트 + 백로그 상태 동기화
+5. **백로그-GitHub 연동** (`github-issues: enabled` 시): 커밋 시 `refs #N` / `closes #N` + 이슈 코멘트 + 완료 항목 백로그에서 제거
 
 ### 테스트 실행
 
@@ -122,4 +122,4 @@ pytest tests/test_step_order.py         # 스텝 순서
 
 - GitHub 리포: [bluejayA/aidlc-devflow](https://github.com/bluejayA/aidlc-devflow)
 - 원본 참조: [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows)
-- 백로그 전체: Claude Code 메모리 `memory/backlog_aidlc.md`
+- 백로그 전체: `devflow-docs/backlog.md`

--- a/docs/guide/github-flow-guide.md
+++ b/docs/guide/github-flow-guide.md
@@ -17,7 +17,11 @@
 
 ### 3단계: 백로그 파일 생성
 
-`memory/backlog_[project].md` 파일을 "백로그 템플릿"에서 복사하여 생성한다.
+`devflow-docs/backlog.md` 파일을 "백로그 템플릿"에서 복사하여 생성한다.
+
+### (선택) GitHub 이슈 연동 활성화
+
+프로젝트 `CLAUDE.md`에 `<!-- github-issues: enabled -->` 설정을 추가하면 GitHub 이슈 자동 생성/연결이 활성화된다. 기본값은 disabled (파일 기반 백로그만 운영).
 
 ---
 
@@ -58,19 +62,27 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
 
 ## 프로젝트별 규칙 (CLAUDE.md용)
 
-백로그-GitHub 이슈 연동이 필요한 프로젝트에 아래를 추가한다. `[owner/repo]`와 `[project]`를 실제 값으로 교체.
+백로그 관리가 필요한 프로젝트에 아래를 추가한다. `[owner/repo]`를 실제 값으로 교체.
 
 ```markdown
-## 백로그-GitHub 이슈 연동 (필수)
+## 백로그 관리
 
-### 백로그 등록 시
-- `memory/backlog_[project].md`에 항목 추가
+### 백로그 파일
+- 위치: `devflow-docs/backlog.md`
+- 구조: Next (3-5건) / Open / Someday
+- Done 항목은 파일에서 제거 (git history로 추적)
+
+### GitHub 이슈 연동
+<!-- github-issues: enabled -->
+> 아래 규칙은 `github-issues: enabled`일 때만 적용한다.
+> disabled일 때는 `devflow-docs/backlog.md` 파일 기반으로만 운영한다.
+
+**백로그 등록 시:**
+- `devflow-docs/backlog.md`에 항목 추가
 - GitHub 이슈를 `enhancement` 라벨로 동시 생성 (`[owner/repo]`)
 - 백로그에 이슈 번호와 링크 기록
 
-### 백로그 구현 시
-백로그 항목을 구현하여 커밋할 때, 연결된 GitHub 이슈와 반드시 연동한다.
-
+**백로그 구현 시:**
 1. **커밋 메시지에 이슈 번호 포함**
    - 진행 중: `refs #N`
    - 완료 시: `closes #N` (머지 시 이슈 자동 클로즈)
@@ -79,68 +91,50 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
    - 구현 시작 시: 간략한 접근 방식 코멘트
    - 커밋 완료 시: 변경 내용 요약 + 커밋 해시 코멘트
 
-3. **백로그 파일 상태 동기화**
-   - 구현 완료 시 `backlog_[project].md`의 상태를 `Done`으로 변경
-   - 현황 카운트(Open/Done/Closed) 갱신
+3. **백로그 파일 정리**
+   - 구현 완료 시 `devflow-docs/backlog.md`에서 해당 항목 제거
 ```
 
 ---
 
 ## 백로그 템플릿
 
-`memory/backlog_[project].md`로 저장한다.
+`devflow-docs/backlog.md`로 저장한다.
 
 ```markdown
----
-name: [프로젝트명] 백로그
-description: [프로젝트] 개선사항 백로그. 카테고리별 정리. GitHub Issues 연동.
-type: project
----
+# Backlog
 
-## 백로그 현황
-
-- **Open**: 0건
-- **Done**: 0건
-- **Closed**: 0건
-- **마지막 정리**: YYYY-MM-DD
+> **완료 항목 조회 방법:**
+> - GitHub: `is:issue is:closed` 필터
+> - Claude: "완료된 백로그 항목 보여줘" 요청 (git history 검색)
 
 ---
 
-## CAT-A: [카테고리명]
+## Next
 
-> [카테고리 설명]
-
-### BL-001: [제목] [P1]
-- **상태**: Open
-- **GitHub**: [#N](https://github.com/[owner/repo]/issues/N)
-- **등록일**: YYYY-MM-DD
-- **출처**: [어디서 발견/요청되었는가]
-- **현재 동작**: [현재 어떻게 동작하는가]
-- **제안**: [어떻게 변경할 것인가]
-- **영향 범위**: [변경되는 파일/컴포넌트]
+(즉시 착수할 3-5건)
+- **BL-001**: [제목] [P1] [#N](https://github.com/[owner/repo]/issues/N)
 
 ---
 
-## CAT-B: [카테고리명]
+## Open
 
-> [카테고리 설명]
+(확인된 개선사항)
+- **BL-002**: [제목] [P2] [#N](https://github.com/[owner/repo]/issues/N)
 
-(항목 추가)
+---
+
+## Someday
+
+(아이디어 단계)
+- **BL-003**: [제목] [P3] [#N](https://github.com/[owner/repo]/issues/N)
 ```
 
-### 백로그 항목 필드 설명
+### 백로그 항목 형식
 
-| 필드 | 필수 | 설명 |
-|------|------|------|
-| 상태 | 필수 | Open / Done / Closed (사유) |
-| GitHub | 필수 | 이슈 링크 |
-| 등록일 | 필수 | 절대 날짜 (상대 날짜 금지) |
-| 출처 | 필수 | 발견 경위 |
-| 현재 동작 | 권장 | 변경 전 상태 |
-| 제안 | 필수 | 변경 내용 |
-| 영향 범위 | 필수 | 변경되는 파일/컴포넌트 |
-| 선행 | 선택 | 의존하는 다른 BL |
-| 관련 | 선택 | 관련된 다른 BL |
+각 항목은 **1줄**로 작성한다: `- **BL-NNN**: [제목] [Px] [#N](link)`
+
+상세 정보가 필요한 경우 GitHub 이슈에 기록한다 (github-issues: enabled일 때).
 
 ### 우선순위 기준
 
@@ -178,8 +172,7 @@ type: project
    └→ git checkout main && git pull
 
 6. 동기화
-   └→ 백로그 상태 → Done
-   └→ 현황 카운트 갱신
+   └→ 백로그에서 완료 항목 제거
 ```
 
 ---
@@ -192,4 +185,4 @@ gh issue close [N] --repo [owner/repo] \
   --comment "[클로즈 사유]"
 ```
 
-백로그에도 상태를 `Closed (not_planned) — [사유]`로 업데이트.
+백로그에서도 해당 항목을 제거한다.

--- a/docs/guide/sample-project-claude-md.md
+++ b/docs/guide/sample-project-claude-md.md
@@ -24,16 +24,24 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
 
 ---
 
-## 백로그-GitHub 이슈 연동 (필수)
+## 백로그 관리
 
-### 백로그 등록 시
-- `memory/backlog_[project].md`에 항목 추가
+### 백로그 파일
+- 위치: `devflow-docs/backlog.md`
+- 구조: Next (3-5건) / Open / Someday
+- Done 항목은 파일에서 제거 (git history로 추적)
+
+### GitHub 이슈 연동
+<!-- github-issues: enabled -->
+> 아래 규칙은 `github-issues: enabled`일 때만 적용한다.
+> disabled일 때는 `devflow-docs/backlog.md` 파일 기반으로만 운영한다.
+
+**백로그 등록 시:**
+- `devflow-docs/backlog.md`에 항목 추가
 - GitHub 이슈를 `enhancement` 라벨로 동시 생성 (`[owner/repo]`)
 - 백로그에 이슈 번호와 링크 기록
 
-### 백로그 구현 시
-백로그 항목을 구현하여 커밋할 때, 연결된 GitHub 이슈와 반드시 연동한다.
-
+**백로그 구현 시:**
 1. **커밋 메시지에 이슈 번호 포함**
    - 진행 중: `refs #N`
    - 완료 시: `closes #N` (머지 시 이슈 자동 클로즈)
@@ -43,6 +51,5 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
    - 구현 시작 시: 간략한 접근 방식 코멘트
    - 커밋 완료 시: 변경 내용 요약 + 커밋 해시 코멘트
 
-3. **백로그 파일 상태 동기화**
-   - 구현 완료 시 백로그의 상태를 `Done`으로 변경
-   - 현황 카운트(Open/Done/Closed) 갱신
+3. **백로그 파일 정리**
+   - 구현 완료 시 `devflow-docs/backlog.md`에서 해당 항목 제거

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -120,6 +120,16 @@ git worktree prune
 [워크트리 제거: [worktree-path]] (워크트리 사용 시)
 ```
 
+**백로그 Next 정리 제안**: `devflow-docs/backlog.md`가 존재하면:
+```
+백로그 Next를 정리할까요?
+- 완료된 항목 제거
+- Open에서 새 항목 승격
+
+→ "정리" 또는 "건너뛰기"
+```
+사용자가 "정리"를 선택하면 파일을 열어 함께 정리한다. "건너뛰기"하면 그대로 진행한다.
+
 **devflow 종료 처리** (devflow-state.md가 존재하는 경우):
 1. `devflow-docs/devflow-state.md`의 `## Current Phase`를 `finished`로 업데이트
 2. state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동
@@ -169,6 +179,16 @@ devflow는 PR 머지 후 종료 처리됩니다.
 ```
 
 **워크트리는 PR이 머지될 때까지 유지한다. 이 단계에서 제거하지 않는다.**
+
+**백로그 Next 정리 제안**: `devflow-docs/backlog.md`가 존재하면:
+```
+백로그 Next를 정리할까요?
+- 완료된 항목 제거
+- Open에서 새 항목 승격
+
+→ "정리" 또는 "건너뛰기"
+```
+사용자가 "정리"를 선택하면 파일을 열어 함께 정리한다. "건너뛰기"하면 그대로 진행한다.
 
 **devflow state 유지**: 옵션 B에서는 devflow-state.md를 아카이브하지 않는다. PR 머지 후 다음 세션에서 using-devflow가 PR 머지 확인 → 종료 처리를 안내한다. devflow-state에 `## Finishing Choice`를 `B (PR pending)` + `## PR URL`을 `[github-pr-url]`로 기록한다.
 

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -101,14 +101,32 @@ metadata:
    ## Selected Approach
    (pending)
    ```
-5. devflow-audit에 로깅: "New aidlc session started" + 사용자 원래 요청
-6. `aidlc-inception-orchestrator` 호출
+5. **백로그 확인 (Lazy Loading)**: `devflow-docs/backlog.md`가 존재하면:
+   - `## Next`, `## Open` 섹션의 항목 수(`- **BL-` 패턴)만 카운트한다. 파일 내용은 로드하지 않는다.
+   - 안내 표시:
+     ```
+     백로그: Next [N]건, Open [M]건
+     → 백로그를 확인하려면 "백로그 보여줘"라고 요청하세요.
+     ```
+   - 사용자가 요청하지 않으면 내용을 로드하지 않고 다음 단계로 진행한다.
+   - 파일이 없으면 이 단계를 건너뛴다.
+6. devflow-audit에 로깅: "New aidlc session started" + 사용자 원래 요청
+7. `aidlc-inception-orchestrator` 호출
 
 ### Resume Flow
 
 1. `devflow-docs/devflow-state.md` 읽기
 2. `devflow-docs/session-summary.md` 읽기 (있으면)
-3. `## Current Phase` 값에 따라 분기:
+3. **백로그 확인 (Lazy Loading)**: `devflow-docs/backlog.md`가 존재하면:
+   - `## Next`, `## Open` 섹션의 항목 수(`- **BL-` 패턴)만 카운트한다. 파일 내용은 로드하지 않는다.
+   - 안내 표시:
+     ```
+     백로그: Next [N]건, Open [M]건
+     → 백로그를 확인하려면 "백로그 보여줘"라고 요청하세요.
+     ```
+   - 사용자가 요청하지 않으면 내용을 로드하지 않고 다음 단계로 진행한다.
+   - 파일이 없으면 이 단계를 건너뛴다.
+4. `## Current Phase` 값에 따라 분기:
 
 #### Phase가 `finished`인 경우
 


### PR DESCRIPTION
Closes #127

## Summary
- `memory/backlog_aidlc.md` (920줄) → `devflow-docs/backlog.md` (48줄)로 마이그레이션
- 3단계 구조: Next / Open / Someday, Done 항목은 파일에서 제거 (git history 추적)
- CLAUDE.md에 `github-issues: enabled/disabled` 설정 키 추가 (조건부 GitHub 연동)
- `aidlc-using-devflow`에 Lazy Loading 게이트 (건수만 표시, 내용 로드 안 함)
- `aidlc-finishing-a-development-branch`에 Next 정리 제안 (옵션 A/B 완료 후)
- docs 3건 + memory 3건 경로/규칙 업데이트

## Test plan
- [x] `devflow-docs/backlog.md` 존재 + 48줄 (목표 200줄 이하)
- [x] Next/Open/Someday 3단계 구조 + 전체 27건 GitHub 이슈 링크 보존
- [x] CLAUDE.md에 `github-issues` 설정 키 + 조건부 안내 확인
- [x] using-devflow Lazy Loading 게이트 (New Flow + Resume Flow)
- [x] finishing-branch Next 정리 제안 (옵션 A + B)
- [x] `memory/backlog` 활성 참조 0건 (과거 이력 docs/plans/ 2건 제외)
- [x] Spec review: 모든 FR PASS, blocking 이슈 없음
- [x] Code review: Critical 1 + Important 2 + Minor 2 → 모두 수정 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)