### PR TITLE
feat: 세션 재개 재검증 최대 횟수 제한 (BL-063)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -9,7 +9,6 @@
 
 ## Next
 
-- **BL-063**: 세션 재개 재검증 최대 횟수 제한 [P2] [#108](https://github.com/bluejayA/aidlc-devflow/issues/108)
 - **BL-065**: SDD 모드 functional-design 전달 문서화 [P2] [#110](https://github.com/bluejayA/aidlc-devflow/issues/110)
 - **BL-074**: 오류 복구 경로 정의 — tech-stack 카탈로그 부재 등 폴백 [P2] [#119](https://github.com/bluejayA/aidlc-devflow/issues/119)
 

--- a/skills/_shared/patterns/session-continuity.md
+++ b/skills/_shared/patterns/session-continuity.md
@@ -182,7 +182,7 @@ CONSTRUCTION 세션 재개 시 construction-orchestrator가 실행.
 ### 재검증 후 복귀 경로
 
 재검증 실패 → debugging 완료 시:
-- construction-orchestrator: debugging Return 수신 → 재검증 재실행
+- construction-orchestrator: debugging Return 수신 → 재검증 재실행 (최대 2회, 초과 시 에스컬레이션)
 - executing-plans: debugging 완료 → 재검증 재실행 → 통과 시 정상 재개
 
 ### 프로세스

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -78,7 +78,15 @@ B) systematic-debugging으로 즉시 조사
 ```
 → A: 전체 실행 후 실패 있으면 debugging 라우팅
 → B: 바로 `aidlc-systematic-debugging` 호출
-→ debugging Return 수신 후 재검증 재실행 (Step 1.5 반복)
+→ debugging Return 수신 후 재검증 재실행 (Step 1.5 반복, 최대 2회)
+
+**재검증 최대 횟수**: 재검증→debugging→재검증 루프는 **최대 2회**까지. 2회 실패 시 에스컬레이션:
+```
+⚠️ 재검증 2회 실패 — 자동 복구 불가
+
+A) 수동으로 디버깅 계속
+B) 재검증 건너뛰고 다음 unit 진행 (devflow-state에 "재검증 실패 미해결" 기록)
+```
 
 ### Step 2: 스테이지 결정
 


### PR DESCRIPTION
Closes #108

## Summary
- construction-orchestrator Step 1.5 재검증→debugging→재검증 루프에 최대 2회 제한 추가
- 2회 실패 시 에스컬레이션 게이트: A) 수동 디버깅 계속 / B) 건너뛰고 다음 unit 진행
- session-continuity.md 재검증 프로토콜 동기화

## Test plan
- [x] 269 tests 전체 통과
- [x] 기존 재검증 프로토콜 동작 변경 없음 (2회 이내는 기존과 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)