### PR TITLE
docs: SDD 모드 functional-design 전달 경로 명시 (BL-065)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -9,7 +9,6 @@
 
 ## Next
 
-- **BL-065**: SDD 모드 functional-design 전달 문서화 [P2] [#110](https://github.com/bluejayA/aidlc-devflow/issues/110)
 - **BL-074**: 오류 복구 경로 정의 — tech-stack 카탈로그 부재 등 폴백 [P2] [#119](https://github.com/bluejayA/aidlc-devflow/issues/119)
 
 ---

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -135,7 +135,9 @@ B) 인라인 모드 — 현재 컨텍스트에서 순차 실행
 
 **A (SDD 모드) 선택 시:**
 1. Comprehensive에서 functional-design이 포함된 경우, SDD 호출 **전에** orchestrator가 unit별로 functional-design을 실행한다
-2. `aidlc-subagent-driven-development` 호출 (인라인 신호: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level]"`)
+2. `aidlc-subagent-driven-development` 호출 (인라인 신호: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level], functional-designs=[devflow-docs/inception/functional-design-*.md]"`)
+   - functional-design 산출물이 있으면 경로를 인라인 신호에 포함. SDD가 서브에이전트에 전달한다.
+   - functional-design이 없으면 (Standard 이하) 해당 필드 생략
 3. SDD 모드에서는 개별 unit 게이트(code-plan 게이트, 구현 게이트)가 **비활성화** — SDD 스킬의 태스크 완료 + R1 리뷰가 품질 게이트 역할
 4. SDD 완료 후 → build-and-test(섹션 3)로 바로 진행
 

--- a/skills/aidlc-subagent-driven-development/SKILL.md
+++ b/skills/aidlc-subagent-driven-development/SKILL.md
@@ -35,15 +35,16 @@ metadata:
 ### 모드 2: Orchestrator 위임 모드 (units.md 기반)
 `aidlc-construction-orchestrator`가 SDD 모드로 호출 시.
 
-**호출 신호**: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level]"`
+**호출 신호**: `"SDD: units=[devflow-docs/inception/units.md], summary=[devflow-docs/session-summary.md], complexity=[level], functional-designs=[devflow-docs/inception/functional-design-*.md]"`
 
 이 신호를 받으면:
 1. units.md에서 unit 목록을 읽고, 각 unit을 태스크로 변환
 2. session-summary.md에서 unit 완료 상태 + units.md의 인터페이스 정의만 참조
-3. **컨텍스트 격리**: 각 unit 서브에이전트에 이전 unit의 code-plan, 구현 코드, 변경 파일 목록 전달 금지
-4. **finishing-branch 비활성화**: orchestrator 위임 모드에서는 `aidlc-finishing-a-development-branch` 호출을 스킵. orchestrator가 후속 처리
-5. **최종 코드 리뷰 비활성화**: orchestrator가 build-and-test를 별도 실행하므로 SDD 내 최종 리뷰 스킵
-6. 모든 unit의 R1 리뷰 통과 → orchestrator에 제어 반환
+3. **functional-design 전달**: `functional-designs` 필드가 있으면 해당 unit의 functional-design 산출물을 서브에이전트에 컨텍스트로 전달한다. 서브에이전트는 functional-design을 재실행하지 않는다. 필드가 없으면 (Standard 이하) 건너뛴다.
+4. **컨텍스트 격리**: 각 unit 서브에이전트에 이전 unit의 code-plan, 구현 코드, 변경 파일 목록 전달 금지
+5. **finishing-branch 비활성화**: orchestrator 위임 모드에서는 `aidlc-finishing-a-development-branch` 호출을 스킵. orchestrator가 후속 처리
+6. **최종 코드 리뷰 비활성화**: orchestrator가 build-and-test를 별도 실행하므로 SDD 내 최종 리뷰 스킵
+7. 모든 unit의 R1 리뷰 통과 → orchestrator에 제어 반환
 
 ## 프로세스 (태스크 반복)
 


### PR DESCRIPTION
Closes #110

## Summary
- construction-orchestrator SDD 인라인 신호에 `functional-designs` 필드 추가
- subagent-driven-development 모드 2에 functional-design 전달 규칙 추가 (항목 3)
- 서브에이전트가 functional-design을 재실행하지 않도록 명시
- Comprehensive + SDD 경로에서 orchestrator→SDD→서브에이전트 산출물 전달 경로 확정

## Test plan
- [x] 269 tests 전체 통과
- [x] 기존 SDD 동작 변경 없음 (문서화 수준, functional-designs 필드 없으면 기존과 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)