### PR TITLE
fix: devflow-state 정합성 — Worktree 필드 기록 + 템플릿 필드 추가 (BL-079, BL-080)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -9,7 +9,8 @@
 
 ## Next
 
-(현재 비어 있음 — Open에서 승격 필요)
+- **BL-031**: deployment-prep 독립 스킬 — Dockerfile + k8s manifest 생성 (MVP) [P2] [#41](https://github.com/bluejayA/aidlc-devflow/issues/41)
+(BL-079, BL-080 완료)
 
 ---
 
@@ -18,7 +19,6 @@
 - **BL-042**: 행동 테스트 계층 (Layer 2) — LLM 기반 스킬 동작 검증 [P2] [#61](https://github.com/bluejayA/aidlc-devflow/issues/61)
 - **BL-044**: Multi-Unit Construction Agent Teams — 독립 유닛 병렬 구현 + 인터페이스 조율 [P2] [#70](https://github.com/bluejayA/aidlc-devflow/issues/70)
 - **BL-045**: dispatching-parallel-agents Agent Teams 강화 — 실행 중 충돌 감지/조율 [P2] [#71](https://github.com/bluejayA/aidlc-devflow/issues/71)
-- **BL-031**: deployment-prep 독립 스킬 — Dockerfile + k8s manifest 생성 (MVP) [P2] [#41](https://github.com/bluejayA/aidlc-devflow/issues/41)
 - **BL-052**: Playwright E2E 자동 검증 + 평가기 비대칭 도구 설계 [P2] [#92](https://github.com/bluejayA/aidlc-devflow/issues/92)
 
 
@@ -40,5 +40,3 @@
 - **BL-070**: 디버깅 루프 소프트 리밋 [P3] [#115](https://github.com/bluejayA/aidlc-devflow/issues/115)
 - **BL-071**: workflow-planning 다이어그램 선택 접근법 반영 [P3] [#116](https://github.com/bluejayA/aidlc-devflow/issues/116)
 - **BL-073**: 컨텍스트 누적 최적화 — 스테이지별 점진 로딩 [P3] [#118](https://github.com/bluejayA/aidlc-devflow/issues/118)
-- **BL-079**: Worktree 필드 미기록 — using-git-worktrees에서 devflow-state 기록 누락 [P3] [#129](https://github.com/bluejayA/aidlc-devflow/issues/129)
-- **BL-080**: devflow-state 템플릿에 Finishing Choice / PR URL 필드 추가 [P3] [#130](https://github.com/bluejayA/aidlc-devflow/issues/130)

--- a/skills/_utils/devflow-state/SKILL.md
+++ b/skills/_utils/devflow-state/SKILL.md
@@ -63,6 +63,14 @@ When creating or updating the state file, maintain this exact structure:
 - branch: [feature/xxx | none]
 - path: [.worktrees/xxx | none]
 
+## Finishing Choice
+<!-- finishing-branch 옵션 B 선택 시 기록. 옵션 A/D는 즉시 finished로 전환 -->
+[B (PR pending) | none]
+
+## PR URL
+<!-- finishing-branch 옵션 B에서 PR 생성 시 기록 -->
+[github-pr-url | none]
+
 ## Extension Configuration
 <!-- 활성화된 extension 목록 -->
 - security: [enabled | disabled]

--- a/skills/aidlc-using-git-worktrees/SKILL.md
+++ b/skills/aidlc-using-git-worktrees/SKILL.md
@@ -149,6 +149,15 @@ git worktree add "$PATH" -b "$BRANCH"
 
 ---
 
+## devflow-state 업데이트
+
+<!-- @state-update: 워크트리 생성 완료 → devflow-state Worktree 필드 기록 -->
+워크트리 생성 완료 후 `devflow-docs/devflow-state.md`의 `## Worktree` 필드를 업데이트한다:
+- `branch`: [branch-name]
+- `path`: [.worktrees/xxx]
+
+스킵된 경우(git 미사용): `branch: none`, `path: none`으로 기록.
+
 ## Return to Orchestrator
 
 conventions 표준 형식. 반환 필드:


### PR DESCRIPTION
Closes #129
Closes #130

## Summary
- **BL-079**: `using-git-worktrees`에 워크트리 생성 후 devflow-state `## Worktree` 필드 업데이트 규칙 추가. `requesting-code-review`와 `review-team-protocol`이 이 필드를 읽어 프로젝트 루트를 결정하므로, 미기록 시 리뷰 경로 오류 가능성 해소.
- **BL-080**: `_utils/devflow-state` 템플릿에 `## Finishing Choice` + `## PR URL` 필드 추가. `finishing-branch` 옵션 B에서 동적 추가하던 필드를 템플릿에 정식 정의.

## Test plan
- [x] 269 tests 전체 통과
- [x] 기존 동작 변경 없음 (필드 정의 + 기록 규칙 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)