### PR TITLE
feat: 디버깅 루프 소프트 리밋 — 3회 초과 시 에스컬레이션 (BL-070)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -10,7 +10,6 @@
 ## Next
 
 - **BL-031**: deployment-prep 독립 스킬 — Dockerfile + k8s manifest 생성 (MVP) [P2] [#41](https://github.com/bluejayA/aidlc-devflow/issues/41)
-(BL-079, BL-080 완료)
 
 ---
 
@@ -37,6 +36,5 @@
 - **BL-067**: NFR 기본값 테이블 정의 [P3] [#112](https://github.com/bluejayA/aidlc-devflow/issues/112)
 - **BL-068**: units 위상 정렬 검증 게이트 [P3] [#113](https://github.com/bluejayA/aidlc-devflow/issues/113)
 - **BL-069**: auto-fix 에러 분류 정교화 [P3] [#114](https://github.com/bluejayA/aidlc-devflow/issues/114)
-- **BL-070**: 디버깅 루프 소프트 리밋 [P3] [#115](https://github.com/bluejayA/aidlc-devflow/issues/115)
 - **BL-071**: workflow-planning 다이어그램 선택 접근법 반영 [P3] [#116](https://github.com/bluejayA/aidlc-devflow/issues/116)
 - **BL-073**: 컨텍스트 누적 최적화 — 스테이지별 점진 로딩 [P3] [#118](https://github.com/bluejayA/aidlc-devflow/issues/118)

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -356,6 +356,14 @@ K 선택/스킵 모두 devflow-audit에 로깅:
 
 **Step 1.5 재검증 Debugging에는 K 게이트를 적용하지 않는다.** K 게이트는 본 Debugging 라우팅(build-and-test 실패 후)에서만 표시.
 
+**디버깅 루프 소프트 리밋**: 동일 unit에서 debugging→build-and-test 루프는 **최대 3회**까지. 3회 실패 시 에스컬레이션:
+```
+⚠️ 동일 unit에서 디버깅 3회 실패 — 자동 복구 한계
+
+A) 수동으로 디버깅 계속 (루프 카운트 리셋)
+B) 이 unit을 실패 상태로 완료 (devflow-state에 "빌드/테스트 실패 미해결" 기록)
+```
+
 ## Interrupt Handling
 <!-- @interrupt: global -->
 


### PR DESCRIPTION
Closes #115

## Summary
- Debugging 라우팅에서 동일 unit의 debugging→build-and-test 루프에 최대 3회 제한 추가
- 3회 실패 시 에스컬레이션: A) 수동 디버깅 계속 (카운트 리셋) / B) 실패 상태로 완료
- BL-063(재검증 2회 제한)과 동일 패턴 적용

## Test plan
- [x] 269 tests 전체 통과
- [x] 기존 디버깅 동작 변경 없음 (3회 이내는 기존과 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)