### PR TITLE
docs: 전체 문서 현행화 — v1.6.0 기준 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [English](README.en.md) | 한국어
 
-![version](https://img.shields.io/badge/version-1.1.0-blue)
-![skills](https://img.shields.io/badge/skills-27-green)
-![tests](https://img.shields.io/badge/tests-95-brightgreen)
+![version](https://img.shields.io/badge/version-1.6.0-blue)
+![skills](https://img.shields.io/badge/skills-27+3_utils-green)
+![tests](https://img.shields.io/badge/tests-269-brightgreen)
 
 AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 Claude Code 개발 워크플로우 플러그인입니다.
 
@@ -53,13 +53,15 @@ AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 C
 
 ---
 
-## Skills 목록 (26개)
+## Skills 목록 (27개 + 유틸리티 3개)
 
 ### AI-DLC 핵심 스테이지
 
 | Skill | 역할 |
 |-------|------|
-| `aidlc-using-devflow` | 오케스트레이터. 전체 라이프사이클 소유 및 구동 |
+| `aidlc-using-devflow` | Entry Orchestrator. 전체 라이프사이클 소유 및 구동. @resume-rules로 세션 재개 분기 관리 |
+| `aidlc-inception-orchestrator` | INCEPTION Phase Orchestrator. 스테이지 순서 + 게이트 관리 |
+| `aidlc-construction-orchestrator` | CONSTRUCTION Phase Orchestrator. unit 루프 + 빌드/테스트/디버깅 관리 |
 | `aidlc-workspace-detection` | 그린필드/브라운필드 판단 + Brownfield 시 tech-stack/code-structure 수집 |
 | `aidlc-requirements-analysis` | 적응형 요구사항 분석. 해석 분기 시 선택지 제시 |
 | `aidlc-user-stories` | 요구사항을 INVEST 기준 사용자 스토리로 변환 (조건부, Pre-Planning) |
@@ -90,7 +92,7 @@ AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 C
 | `aidlc-systematic-debugging` | 버그/실패 발생 시 근본 원인 조사 강제 + 실패 이력 분석 |
 | `aidlc-verification-before-completion` | 완료 선언 전 실제 검증 명령 실행 강제 + 회귀 테스트 RED-GREEN 검증 |
 | `aidlc-finishing-a-development-branch` | 개발 완료 후 병합/PR/유지/폐기 처리 |
-| `aidlc-requesting-code-review` | 2-stage 코드 리뷰 요청 (spec compliance → code quality). 리뷰 로직의 Single Source of Truth |
+| `aidlc-requesting-code-review` | 4-stage 코드 리뷰 요청 (R1 단일/R2 Council/R3 Agent Teams/Ra 자동). Distrust by Default. 리뷰 로직의 Single Source of Truth |
 | `aidlc-receiving-code-review` | 코드 리뷰 피드백 수신 시 체계적 처리 |
 | `aidlc-dispatching-parallel-agents` | 독립적 태스크를 병렬 서브에이전트로 디스패치 |
 | `aidlc-writing-skills` | 새 스킬 개발 시 TDD 방식 + CSO 원칙 적용 |
@@ -99,8 +101,9 @@ AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 C
 
 | Skill | 역할 |
 |-------|------|
-| `_utils/devflow-state` | `devflow-docs/devflow-state.md` 읽기/쓰기 |
+| `_utils/devflow-state` | `devflow-docs/devflow-state.md` 읽기/쓰기. Worktree, Finishing Choice, PR URL 필드 포함 |
 | `_utils/devflow-audit` | `devflow-docs/audit.md` append-only 로깅 |
+| `_utils/devflow-solutions` | Knowledge Compounding — 디버깅 해결 사례 구조화 저장/검색 |
 
 ### 공유 규약 문서
 
@@ -120,7 +123,7 @@ AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 C
 | `_shared/patterns/question-format-guide.md` | 질문 설계 원칙 — 선택지 설계, 수준 적응, 모순 감지 |
 | `_shared/patterns/tech-stack-defaults.md` | 기술 스택 인덱스 — 프리셋, 정책 모드, 적용 규칙 |
 | `_shared/patterns/tech-stack-catalog.md` | 계층별 기술 카탈로그 — 선택지 생성 데이터 |
-| `_shared/reviewers/` | 리뷰 서브에이전트 프롬프트 8종 (artifact, code-plan, code-reviewer, implementer, spec, quality, skill, spec-document, plan-document) |
+| `_shared/reviewers/` | 리뷰 서브에이전트 프롬프트 12종 (artifact, code-plan, code-quality, code, council-review-protocol, implementer, maintainability, plan-document, security, skill, spec-document, spec) |
 
 #### YAML 메타데이터 규약
 
@@ -156,7 +159,9 @@ devflow-docs/
 │   └── build-and-test/
 │       ├── build-instructions.md  # 빌드 지침
 │       └── test-instructions.md   # 테스트 지침
-├── devflow-state.md        # 현재 단계 상태 (세션 재개용)
+├── backlog.md              # 백로그 (Next/Open/Someday 3단계)
+├── session-summary.md      # 세션 요약 (재개 시 맥락 복원)
+├── devflow-state.md        # 현재 단계 상태 (세션 재개용, @resume-rules 참조)
 └── audit.md                # 전체 상호작용 로그 (append-only)
 ```
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,13 +1,13 @@
 # 인수인계 문서
 
-> 작성일: 2026-03-18 | 플러그인 버전: v1.1.0
+> 작성일: 2026-04-02 | 플러그인 버전: v1.6.0
 
 ---
 
 ## 프로젝트 개요
 
 AI-DLC 방법론을 오케스트레이터 중심 아키텍처로 구현한 Claude Code 개발 워크플로우 플러그인.
-2026-03-10부터 개발 시작, 188 commits, 27개 스킬 + 95개 테스트.
+2026-03-10부터 개발 시작, 27개 스킬 + 3개 유틸리티 + 5개 리뷰 에이전트 + 269개 테스트.
 
 ### 온보딩 필독 문서
 
@@ -16,8 +16,9 @@ AI-DLC 방법론을 오케스트레이터 중심 아키텍처로 구현한 Claud
 | 1 | [how-it-works.md](guide/how-it-works.md) | 기술 용어 없이 전체 흐름 이해 |
 | 2 | [user-guide.md](guide/user-guide.md) | 시작, 질문 방식, 게이트, 독립 스킬 |
 | 3 | [architecture.md](guide/architecture.md) | 3단 위임 체인, 스킬 패턴 7종 |
-| 4 | [operator-guide.md](guide/operator-guide.md) | 기술 카탈로그, 질문 원칙 커스터마이즈 |
+| 4 | [operator-guide.md](guide/operator-guide.md) | 기술 카탈로그, 질문 원칙, NFR 프리셋 커스터마이즈 |
 | 5 | [consistency-checklist.md](guide/consistency-checklist.md) | 스킬 수정 시 정합성 검증 체크리스트 |
+| 6 | [nfr-domain-presets.md](guide/nfr-domain-presets.md) | CLAUDE.md 기반 NFR 도메인 프리셋 예제 |
 
 ---
 
@@ -33,53 +34,31 @@ AI-DLC 방법론을 오케스트레이터 중심 아키텍처로 구현한 Claud
 | v0.8.0 | Brownfield 분석 (workspace-detection) |
 | v0.9.0 | Session Continuity + 태스크 재검증 + TDD 명시 |
 | v1.0.0 | Superpowers 독립 구현 + 코드 리뷰 체계 + 훅 시스템 |
-| v1.1.0 | 메타 태그 시스템 + 테스트 인프라 Phase 2 (95개 테스트) |
+| v1.1.0 | 메타 태그 시스템 + 테스트 인프라 Phase 2 |
+| v1.2.0 | Agent-Council 리뷰 인프라 + application-design/code 리뷰 |
+| v1.3.0 | Code Review Agent Teams (R3) + Distrust by Default |
+| v1.4.1 | Verification Contract + Self-Healing Loop |
+| v1.5.0 | SDD 기본화 + 정량 루브릭 + Distrust by Default + Knowledge Compounding |
+| v1.6.0 | P1 Sprint (게이트 UX 3건) + 워크스페이스 캐시 + 백로그 재설계 + 상태 전환 문서화 |
 
 ### 코드 품질
 
-- 테스트: 95개 전체 통과 (`bash tests/run-all.sh`)
+- 테스트: 269개 전체 통과 (`bash tests/run-all.sh`)
 - 스킬 메타데이터 정합성: 100%
-- 미커밋 변경: 없음
-- 리모트 브랜치: `main`만 존재 (정리 완료)
+- 테스트 인프라: 12개 테스트 파일 + 20개 시나리오 (YAML)
 
 ---
 
 ## 백로그 현황
 
-### Open 이슈 (8건)
+백로그 파일: `devflow-docs/backlog.md` (Next/Open/Someday 3단계)
+GitHub Issues: [`bluejayA/aidlc-devflow`](https://github.com/bluejayA/aidlc-devflow/issues)
 
-#### 다음 우선순위 권장 순서
+- **Next**: 1건 (BL-031 deployment-prep)
+- **Open**: 4건 (대규모 기능 — Agent Teams, LLM 행동 테스트, Playwright E2E)
+- **Someday**: 12건
 
-**1순위 — Agent-Council 리뷰 (CAT-G)**
-
-의존 관계: BL-025 → BL-026 + BL-027 (병렬 가능)
-
-| ID | 이슈 | 우선순위 | 내용 |
-|----|------|---------|------|
-| BL-025 | [#30](https://github.com/bluejayA/aidlc-devflow/issues/30) | P1 | agent-council 리뷰 공통 인프라 — CLI 감지, risk scoring, 프롬프트/스키마 |
-| BL-026 | [#31](https://github.com/bluejayA/aidlc-devflow/issues/31) | P1 | application-design agent-council 리뷰 |
-| BL-027 | [#32](https://github.com/bluejayA/aidlc-devflow/issues/32) | P1 | code agent-council 리뷰 |
-
-**2순위 — 워크플로우 개선**
-
-| ID | 이슈 | 우선순위 | 내용 |
-|----|------|---------|------|
-| BL-023 | [#28](https://github.com/bluejayA/aidlc-devflow/issues/28) | P1 | Flow 패널 내부 스텝 진행 표시 |
-| BL-021 | [#25](https://github.com/bluejayA/aidlc-devflow/issues/25) | P1 | GitHub Flow 연동 — 이슈/PR/머지 자동화 |
-
-**3순위 — 장기 (P3, 이슈 미생성)**
-
-| ID | 내용 |
-|----|------|
-| BL-017 | infrastructure-design 스킬 |
-| BL-018 | 콘텐츠 갭 스킬 (depth-levels, error-handling 등) |
-| BL-019 | 장기 컨셉 (C4 Model, operations phase) |
-
-### 완료 통계
-
-- **Done**: 14건
-- **Closed (not_planned/duplicate)**: 6건
-- **Open**: 8건 (P1: 5, P3: 3)
+GitHub 연동은 CLAUDE.md의 `<!-- github-issues: enabled -->` 설정으로 제어.
 
 ---
 
@@ -92,11 +71,12 @@ AI-DLC 방법론을 오케스트레이터 중심 아키텍처로 구현한 Claud
 3. **증거 우선**: 완료 주장 전 반드시 검증 실행
 4. **정합성 체크**: 스킬 수정 시 `docs/guide/consistency-checklist.md` 확인
 5. **백로그-GitHub 연동** (`github-issues: enabled` 시): 커밋 시 `refs #N` / `closes #N` + 이슈 코멘트 + 완료 항목 백로그에서 제거
+6. **재검증 리밋**: 세션 재개 재검증 최대 2회, 디버깅 루프 최대 3회
 
 ### 테스트 실행
 
 ```bash
-# 전체 테스트 (95개)
+# 전체 테스트 (269개)
 bash tests/run-all.sh
 
 # 개별 테스트
@@ -104,6 +84,10 @@ pytest tests/test_meta_tag_format.py    # 메타 태그 형식
 pytest tests/test_graph_validator.py    # 그래프 구조
 pytest tests/test_routing_engine.py     # 라우팅 로직
 pytest tests/test_step_order.py         # 스텝 순서
+pytest tests/test_construction_k_gate.py # K-gate + 리뷰 게이트
+pytest tests/test_verification_contract.py # Verification Contract
+pytest tests/test_quantitative_rubric.py # 정량 루브릭
+pytest tests/test_devflow_solutions.py  # Knowledge Compounding
 ```
 
 ### 주요 파일 위치
@@ -114,7 +98,8 @@ pytest tests/test_step_order.py         # 스텝 순서
 | 공유 규약 | `skills/_shared/devflow-conventions.md` |
 | 게이트 패턴 | `skills/_shared/gate-patterns.md` |
 | TDD 프로토콜 | `skills/_shared/tdd-protocol.md` |
-| 배포용 CLAUDE.md 템플릿 | `docs/claude-md-devflow-only.md` |
+| 세션 연속성 | `skills/_shared/patterns/session-continuity.md` |
+| NFR 프리셋 가이드 | `docs/guide/nfr-domain-presets.md` |
 
 ---
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -258,8 +258,12 @@ graph LR
 | `artifact-reviewer-prompt.md` | INCEPTION 산출물 | application-design 게이트 |
 | `spec-reviewer-prompt.md` | Spec compliance | requesting-code-review Stage 1 |
 | `code-quality-reviewer-prompt.md` | 코드 품질 + OWASP | requesting-code-review Stage 2 |
+| `security-reviewer-prompt.md` | 보안 리뷰 | requesting-code-review Stage 3 |
+| `maintainability-reviewer-prompt.md` | 유지보수성 리뷰 | requesting-code-review Stage 4 |
 | `code-reviewer-prompt.md` | Spec + Quality 통합 | construction-orchestrator |
 | `code-plan-reviewer-prompt.md` | 코드 계획 | code-generation PART 1 |
+| `council-review-protocol.md` | Council/Teams 리뷰 프로토콜 | requesting-code-review R2/R3 |
+| `implementer-prompt.md` | 서브에이전트 구현자 | subagent-driven-development |
 | `skill-reviewer-prompt.md` | 스킬 검증 | writing-skills REFACTOR |
 
 ### Depth 정책
@@ -342,8 +346,10 @@ graph TD
 
 ### 현재 적용 범위
 
-- `aidlc-inception-orchestrator` — 8 steps, 11 gates, 5 conditions
-- `aidlc-construction-orchestrator` — 3 steps, 5 gates, 1 interrupt
+- `aidlc-inception-orchestrator` — 8 steps, 12 gates, 5 conditions, 4 `@state-update`
+- `aidlc-construction-orchestrator` — 3 steps, 5 gates, 1 interrupt, 3 `@state-update`
+- `aidlc-using-devflow` — `@resume-rules` (5분기) + 3 `@state-update`
+- `aidlc-finishing-a-development-branch` — 3 `@state-update` (옵션 A/B/D)
 
 규격 상세: `_shared/patterns/meta-tag-standard.md`
 
@@ -387,11 +393,12 @@ skills/
 |   ├── gate-patterns.md           <- 게이트 패턴 (인터럽트 포함)
 |   ├── tdd-protocol.md            <- TDD 규약
 |   ├── import-review-protocol.md  <- Import/Generate 프로토콜
-|   ├── patterns/                  <- 공유 패턴 (12개)
-|   └── reviewers/                 <- 리뷰어 프롬프트 (8개)
+|   ├── patterns/                  <- 공유 패턴 (16개)
+|   └── reviewers/                 <- 리뷰어 프롬프트 (12개)
 ├── _utils/
 |   ├── devflow-audit/             <- 감사 로그
-|   └── devflow-state/             <- 상태 관리
+|   ├── devflow-solutions/         <- Knowledge Compounding 캐시
+|   └── devflow-state/             <- 상태 관리 (Worktree, Finishing Choice, PR URL 포함)
 hooks/
 ├── hooks.json                     <- SessionStart 이벤트
 └── session-start                  <- 안내 메시지 출력
@@ -408,7 +415,13 @@ tests/
 ├── test_graph_validator.py        <- L1 정적 그래프 검증
 ├── test_routing_simulator.py      <- L2 라우팅 시뮬레이션
 ├── test_routing_engine.py         <- 엔진 단위 테스트
-└── test_step_order.py             <- L3 스텝 순서 검증
+├── test_step_order.py             <- L3 스텝 순서 검증
+├── test_construction_k_gate.py    <- K-gate + 리뷰 게이트 검증
+├── test_verification_contract.py  <- Verification Contract + Self-Healing
+├── test_quantitative_rubric.py    <- 정량 루브릭 계산
+├── test_devflow_solutions.py      <- Knowledge Compounding
+├── test_agent_teams_review.py     <- Agent Teams 협업 리뷰
+└── test_conftest_fixtures.py      <- conftest 픽스처 검증
 docs/
 ├── guide/                         <- 가이드 문서
 |   └── skill-design-patterns/     <- 스킬 설계 패턴 외부 공개 가이드

--- a/docs/guide/consistency-checklist.md
+++ b/docs/guide/consistency-checklist.md
@@ -8,12 +8,14 @@
 
 > 오케스트레이터 SKILL.md 수정 시 반드시 확인.
 
-메타 태그(`@gate`, `@gate-option`, `@step`, `@condition`)가 삽입된 파일을 수정할 때:
+메타 태그(`@gate`, `@gate-option`, `@step`, `@condition`, `@state-update`, `@resume-rules`)가 삽입된 파일을 수정할 때:
 
 - [ ] 게이트 추가/삭제 시 `@gate` + `@gate-option` 태그도 함께 수정했는가
 - [ ] 스텝 순서 변경 시 `@step` 번호를 재조정했는가
 - [ ] 조건 분기 변경 시 `@condition` 태그를 업데이트했는가
+- [ ] devflow-state 업데이트 지점 변경 시 `@state-update` 주석을 동기화했는가
+- [ ] Resume Flow 분기 변경 시 `@resume-rules` 주석 블록을 업데이트했는가
 - [ ] `bash tests/run-all.sh` 실행 시 전체 통과하는가
 
-**검증 방법**: `bash tests/run-all.sh` — 69개 테스트가 불일치를 자동 검출
+**검증 방법**: `bash tests/run-all.sh` — 269개 테스트가 불일치를 자동 검출
 **규격 참조**: `_shared/patterns/meta-tag-standard.md` → Maintenance 섹션

--- a/docs/guide/operator-guide.md
+++ b/docs/guide/operator-guide.md
@@ -171,6 +171,11 @@ A) REST API — 우리 팀 표준, API Gateway 연동 가능
 | **Brainstorming 필수 여부** | `## Brainstorming HARD-GATE` | 항상 필수 | 반복 작업에 한해 스킵 허용 |
 | **session-summary 조기 업데이트** | `session-continuity.md` | 핵심 결정 시점마다 | 단순 작업에서 비활성화 가능 |
 | **인터럽트 핸들러** | `interrupt-handler.md` | 모든 게이트에 적용 | 의도 분류 테이블 커스터마이징 가능 |
+| **재검증 최대 횟수** | `construction-orchestrator` Step 1.5 | 2회 | 안정적 환경에서 1회로 축소 가능 |
+| **디버깅 루프 리밋** | `construction-orchestrator` Debugging 라우팅 | 3회 | 복잡한 프로젝트에서 5회로 확대 가능 |
+| **Lazy Loading 게이트** | `using-devflow` Resume/New Flow | 활성 | 백로그 미사용 시 영향 없음 |
+| **GitHub 이슈 연동** | 프로젝트 `CLAUDE.md` | enabled | `<!-- github-issues: disabled -->` 로 비활성화 |
+| **NFR 도메인 프리셋** | 프로젝트 `CLAUDE.md` | 없음 | [nfr-domain-presets.md](nfr-domain-presets.md) 참조 |
 
 ### 조정 방법
 

--- a/docs/guide/sample-project-claude-md.md
+++ b/docs/guide/sample-project-claude-md.md
@@ -53,3 +53,18 @@ GitHub 작업은 모두 `gh` CLI로 수행한다. MCP GitHub 도구는 사용하
 
 3. **백로그 파일 정리**
    - 구현 완료 시 `devflow-docs/backlog.md`에서 해당 항목 제거
+
+---
+
+## NFR 기본 도메인 (선택)
+
+> NFR 수집 시 도메인 질문을 스킵하고 아래 기본값을 우선 적용합니다.
+> 예제: [nfr-domain-presets.md](nfr-domain-presets.md)
+
+```markdown
+### NFR 기본 도메인
+- 프로젝트 도메인: [도메인명]
+- 가용성: [기본값]
+- 응답 시간: [기본값]
+- 보안: [기본값]
+```

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -166,14 +166,25 @@ devflow-docs/
 │   ├── workspace.md          ← 워크스페이스 분석 결과
 │   ├── requirements.md       ← 요구사항 문서
 │   ├── workflow-plan.md      ← 워크플로우 계획
-│   ├── application-design.md ← 설계 문서 (선택)
-│   └── session-summary.md    ← 세션 요약 (재개용)
+│   └── application-design.md ← 설계 문서 (선택)
 ├── construction/
 │   └── {unit-name}/
 │       ├── functional-design.md ← 기능 설계
 │       └── code-plan.md         ← 코드 계획
-└── devflow-state.md          ← 상태 추적
+├── backlog.md                ← 백로그 (Next/Open/Someday)
+├── session-summary.md        ← 세션 요약 (재개용)
+├── devflow-state.md          ← 상태 추적
+└── audit.md                  ← 상호작용 로그
 ```
+
+### 세션 재개 시
+
+재개 시 devflow-state의 상태에 따라 자동 분기됩니다:
+- `finished` → 이전 플로우 아카이브 후 새 작업 시작
+- `complete + PR pending` → PR 머지 확인
+- `INCEPTION/CONSTRUCTION` → 해당 단계에서 재개
+
+백로그가 있으면 건수만 표시하고, 내용은 요청 시에만 로드합니다 (Lazy Loading).
 
 ---
 


### PR DESCRIPTION
## Summary
v1.1.0 시점에서 멈춰있던 문서 7개를 v1.6.0 기준으로 동기화합니다.

- **README.md**: 버전 배지 1.1.0→1.6.0, 테스트 95→269, 스킬 목록에 orchestrator 2개 + devflow-solutions 추가, 리뷰어 8→12종, 산출물 구조에 backlog/session-summary 추가
- **HANDOVER.md**: 전면 재작성 — v1.2.0~v1.6.0 마일스톤 추가, 백로그 현황 갱신
- **architecture.md**: 리뷰어 프롬프트 12종, @state-update/@resume-rules 범위, 테스트 파일 12개
- **operator-guide.md**: 재검증 리밋, 디버깅 루프 리밋, Lazy Loading, GitHub 연동, NFR 프리셋 조정 항목
- **user-guide.md**: 산출물 구조 + 세션 재개 분기 설명
- **consistency-checklist.md**: 새 메타 태그 체크 항목 + 테스트 수 갱신
- **sample-project-claude-md.md**: NFR 기본 도메인 섹션

## Test plan
- [x] 269 tests 전체 통과
- [x] 스킬 변경 없음 (문서만 업데이트)
- [x] 수치(버전, 스킬 수, 테스트 수, 리뷰어 수)를 실제 코드/테스트 결과와 대조 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)