### PR TITLE
feat: 오케스트레이터 게이트 간소화 3건

### DIFF
--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -171,19 +171,10 @@ A) 선택 시: `"aidlc-requirements-analysis: UPDATE — 기존 분석 유지, [
 
 requirements-analysis 게이트 통과 후, workflow-planning 호출 전에 실행.
 Pre-Planning은 INCEPTION 내 스테이지 그룹명이며, workflow-plan.md의 `### PRE-PLANNING` 섹션에 결과가 기록된다.
-Minimal/Comprehensive는 자동 분기, Standard만 사용자 게이트.
 
-**Minimal complexity**: 자동 스킵. 사용자에게 안내 후 workflow-planning으로 직행:
-```
-Minimal complexity — Pre-Planning(User Stories, NFR) 자동 스킵
-→ 워크플로우 계획으로 진행합니다.
-```
+**Minimal complexity**: 안내 없이 workflow-planning으로 직행. devflow-audit에만 `"Pre-Planning skipped (Minimal)"` 기록.
 
-**Comprehensive complexity**: 자동 포함. 사용자에게 안내 후 User-Stories 게이트로 진행:
-```
-Comprehensive complexity — Pre-Planning(User Stories + NFR) 자동 포함
-→ User Stories 작성을 시작합니다.
-```
+**Comprehensive complexity**: 안내 없이 User-Stories 게이트로 직행. devflow-audit에만 `"Pre-Planning included (Comprehensive)"` 기록.
 
 **Standard complexity**: 3-option 게이트 제시
 

--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -217,15 +217,14 @@ H) 보류 (나중에 돌아옴) → HELD 상태 저장, NFR-Requirements 게이�
 
 A) 선택 시: `"aidlc-user-stories: UPDATE — 기존 스토리 유지, [사용자 변경 요청 내용] 반영"` 인라인 신호로 재호출
 
-### 6. NFR-Requirements 게이트 [모드 선택 게이트 + 표준 게이트 + Hold]
-<!-- @gate: nfr-requirements-mode -->
+### 6. NFR-Requirements 게이트 [통합 게이트]
+<!-- @gate: nfr-requirements -->
 <!-- @gate-option: A -> nfr-requirements {generate} -->
 <!-- @gate-option: B -> nfr-requirements {import} -->
 
 Pre-Planning Gate에서 nfr-requirements 실행이 결정된 경우에만.
 NFR을 건너뛰려면 Pre-Planning Gate에서 C(워크플로우 직행)를 선택한다.
 
-**6a. 모드 선택 (오케스트레이터 소유)**:
 ```
 NFR 요구사항을 어떻게 진행하시겠습니까?
 
@@ -236,17 +235,7 @@ B) 이미 작성된 NFR 문서가 있음 (IMPORT)
 A → `"Mode: GENERATE"` 인라인 신호로 aidlc-nfr-requirements 호출
 B → `"Mode: IMPORT"` 인라인 신호로 aidlc-nfr-requirements 호출
 
-<!-- @gate: nfr-requirements-result -->
-<!-- @gate-option: A -> nfr-requirements {재호출} -->
-<!-- @gate-option: B -> workflow-planning -->
-<!-- @gate-option: H -> workflow-planning {held} -->
-**6b. 결과 게이트**:
-```
-[nfr-requirements 결과 표시]
-A) 변경 요청 (예: 성능 기준, 보안 요건, 가용성 목표 등) → nfr-requirements 재호출
-B) 승인, 다음 단계 진행 → workflow-planning
-H) 보류 (나중에 돌아옴) → HELD 상태 저장, workflow-planning으로 진행
-```
+스킬 반환 후 결과를 사용자에게 표시한다. 변경 요청은 자유 발화로 처리하고, "승인" 발화 시 workflow-planning으로 진행한다. "보류" 발화 시 HELD 상태 저장 후 workflow-planning으로 진행한다.
 
 ### 7. workflow-planning 게이트 [2단계 게이트]
 <!-- @gate: workflow-planning-approach -->

--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -210,8 +210,8 @@ A) 선택 시: `"aidlc-user-stories: UPDATE — 기존 스토리 유지, [사용
 
 ### 6. NFR-Requirements 게이트 [통합 게이트]
 <!-- @gate: nfr-requirements -->
-<!-- @gate-option: A -> nfr-requirements {generate} -->
-<!-- @gate-option: B -> nfr-requirements {import} -->
+<!-- @gate-option: A -> workflow-planning {generate} -->
+<!-- @gate-option: B -> workflow-planning {import} -->
 
 Pre-Planning Gate에서 nfr-requirements 실행이 결정된 경우에만.
 NFR을 건너뛰려면 Pre-Planning Gate에서 C(워크플로우 직행)를 선택한다.

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -128,82 +128,77 @@ metadata:
    - 파일이 없으면 이 단계를 건너뛴다.
 4. `## Current Phase` 값에 따라 분기:
 
-<!-- @resume-rules (상태 분기 요약)
-  finished                          → archive state+summary, then New Flow
-  complete + Finishing=="B (PR pending)" → PR 머지 확인 게이트
-  complete (Finishing 없음)          → finishing-branch 실행 안내
-  INCEPTION | CONSTRUCTION          → 해당 orchestrator 호출
-  파싱 불가 (Error Handling)          → 백업 + New Flow
--->
+### 상태 디스패치 테이블
 
-#### Phase가 `finished`인 경우
+| Phase 값 | 조건 | 동작 | 게이트 |
+|----------|------|------|--------|
+| `finished` | — | 아카이브 → New Flow | 없음 (자동) |
+| `complete` | Finishing == "B (PR pending)" | PR 자동 확인 → 게이트 | A/B |
+| `complete` | Finishing 없음 | — | A/B |
+| `INCEPTION` | — | — | A/B |
+| `CONSTRUCTION` | — | — | A/B |
+| 파싱 불가 | — | 백업 → New Flow | 없음 (자동) |
 
-이전 플로우가 완전히 종료된 상태. 아카이브 처리가 누락된 경우.
+### 자동 처리 경로
 
-```
-## aidlc — 이전 플로우 완료됨
+**`finished`**: state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동 후 New Flow 진행. 사용자 안내 없음.
 
-이전 작업이 완료된 상태입니다.
+**파싱 불가**: `devflow-docs/.archive/devflow-state-backup-[timestamp].md`로 백업 후 New Flow 진행.
 
-→ 새 작업을 시작합니다.
-```
+### 게이트 경로
 
-state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동 후 New Flow 진행.
-- `devflow-docs/.archive/devflow-state-[timestamp].md`
-- `devflow-docs/.archive/session-summary-[timestamp].md` (있으면)
-
-#### Phase가 `complete`이고 `## Finishing Choice`가 `B (PR pending)`인 경우
-
-PR 생성 후 머지 대기 중인 상태.
-
-```
-## aidlc — PR 머지 대기 중
-
-이전 작업의 PR이 아직 열려있습니다.
-PR URL: [## PR URL 값]
-
-A) PR 머지 완료 → devflow 종료 처리
-B) PR 아직 진행 중 → 다른 작업 시작
-C) PR 확인 후 결정
-```
+#### `complete` + PR pending
 
 <!-- @state-update: PR 머지 확인 → Current Phase를 finished로 -->
+
+`gh pr view [PR URL] --json state`로 PR 상태를 자동 확인한 뒤 게이트를 제시한다.
+
+**PR 이미 머지된 경우:**
+```
+## aidlc — PR 머지 확인됨
+
+PR [URL]이 머지되었습니다.
+
+A) devflow 종료 처리 → 아카이브 + 워크트리 정리 + New Flow
+B) 새 작업 시작 (아카이브만)
+```
+
+**PR 아직 열린 경우:**
+```
+## aidlc — PR 대기 중
+
+PR [URL]이 아직 열려있습니다.
+
+A) devflow 종료 처리 (PR 머지 완료로 간주)
+B) 다른 작업 시작 (아카이브)
+```
+
 A 선택 시:
-- `gh pr view [PR URL] --json state`로 머지 확인 (가능한 경우)
 - devflow-state의 `## Current Phase`를 `finished`로 업데이트
-- state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동
+- state와 session-summary를 `.archive/`로 이동
 - 워크트리 존재 시 제거 (`git worktree remove` + `git worktree prune`)
 - devflow-audit에 로깅: `"Flow finished — PR merged"`
-- 새 작업 시작 여부 안내
 
 B 선택 시:
-- state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동
+- state와 session-summary를 `.archive/`로 이동
 - New Flow 진행
 
-C 선택 시:
-- PR 상태를 `gh pr view`로 확인 후 결과에 따라 A 또는 재안내
-
-#### Phase가 `complete`인 경우 (Finishing Choice 없음)
-
-CONSTRUCTION은 완료됐지만 finishing-branch를 아직 실행하지 않은 상태.
+#### `complete` (Finishing Choice 없음)
 
 ```
 ## aidlc — CONSTRUCTION 완료, 브랜치 처리 대기
-
-INCEPTION + CONSTRUCTION이 완료되었습니다.
 
 A) aidlc-finishing-a-development-branch 실행 → 브랜치 처리
 B) 새 작업 시작 (기존 상태 초기화)
 ```
 
-#### Phase가 `INCEPTION` 또는 `CONSTRUCTION`인 경우 (기존 동작)
+#### `INCEPTION` 또는 `CONSTRUCTION`
 
 ```
 ## aidlc — 진행 중인 작업 발견
 
 현재 단계: [Current Phase] > [Current Stage]
 완료된 스테이지: [list]
-마지막 완료: [session-summary의 최근 완료 항목] (있으면)
 
 A) 이전 작업 재개
 B) 새 작업 시작 (기존 상태 초기화)
@@ -211,12 +206,10 @@ B) 새 작업 시작 (기존 상태 초기화)
 
 A 선택 시:
 - devflow-audit에 로깅: `"Session resumed at [stage] — commit: [git rev-parse --short HEAD]"`
-- `## Current Phase` 확인하여 해당 Phase Orchestrator 호출:
-  - `INCEPTION` → `aidlc-inception-orchestrator` 호출
-  - `CONSTRUCTION` → `aidlc-construction-orchestrator` 호출
+- 해당 Phase Orchestrator 호출
 
 B 선택 시:
-- 기존 state와 session-summary(있으면)를 `devflow-docs/.archive/`로 이동
+- state와 session-summary를 `.archive/`로 이동
 - New Flow 진행
 
 ## Phase 전환

--- a/tests/scenarios/inception-comprehensive-all.yaml
+++ b/tests/scenarios/inception-comprehensive-all.yaml
@@ -7,8 +7,7 @@ inputs:
     complexity-declaration: B
     requirements-analysis: B
     user-stories: B
-    nfr-requirements-mode: A
-    nfr-requirements-result: B
+    nfr-requirements: A
     workflow-planning-approach: A
     workflow-planning-env: C
 expect:

--- a/tests/scenarios/inception-held-revisit.yaml
+++ b/tests/scenarios/inception-held-revisit.yaml
@@ -8,8 +8,7 @@ inputs:
     requirements-analysis: B
     pre-planning: A
     user-stories: H
-    nfr-requirements-mode: A
-    nfr-requirements-result: B
+    nfr-requirements: A
     workflow-planning-approach: A
     workflow-planning-env: C
 expect:

--- a/tests/scenarios/inception-standard-nfr-only.yaml
+++ b/tests/scenarios/inception-standard-nfr-only.yaml
@@ -7,8 +7,7 @@ inputs:
     complexity-declaration: B
     requirements-analysis: B
     pre-planning: B
-    nfr-requirements-mode: A
-    nfr-requirements-result: B
+    nfr-requirements: A
     workflow-planning-approach: B
     workflow-planning-env: C
 expect:

--- a/tests/scenarios/inception-standard-user-stories.yaml
+++ b/tests/scenarios/inception-standard-user-stories.yaml
@@ -8,8 +8,7 @@ inputs:
     requirements-analysis: B
     pre-planning: A
     user-stories: B
-    nfr-requirements-mode: A
-    nfr-requirements-result: B
+    nfr-requirements: A
     workflow-planning-approach: A
     workflow-planning-env: C
 expect:


### PR DESCRIPTION
Closes #(없음 — 세션 내 직접 도출)

## Summary
- **NFR 이중 게이트 병합**: 모드 선택(6a) + 결과 확인(6b) → 단일 게이트로 통합. 사용자 중단 1회 감소
- **Pre-Planning 자동분기 안내 제거**: Minimal/Comprehensive는 결과가 정해져 있으므로 안내 없이 직행. devflow-audit에만 기록
- **Phase 분기 테이블화**: using-devflow Resume Flow 83줄 중첩 조건문 → 상태 디스패치 테이블 + 경로별 섹션. PR 게이트 C 옵션 제거 (gh pr view 자동 확인)

## Test plan
- [x] 278 기존 테스트 전체 PASS (regression 없음)
- [x] NFR 관련 4개 시나리오 업데이트 + 통과 (nfr-only, user-stories, held-revisit, comprehensive)
- [x] 그래프 순환 감지 테스트 통과 (nfr-requirements → workflow-planning 탈출 경로 확인)
- [x] Pre-Planning 시나리오 (minimal-fast, comprehensive-all) 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)