### PR TITLE
feat: review-gate + revalidation 패턴 추출 — 중복 제거

### DIFF
--- a/skills/_shared/patterns/review-gate-pattern.md
+++ b/skills/_shared/patterns/review-gate-pattern.md
@@ -1,0 +1,35 @@
+# Review Gate Pattern
+
+리뷰 결과(Verdict)에 따른 게이트 분기의 공통 패턴. 오케스트레이터에서 리뷰 결과를 받아 사용자에게 선택지를 제시할 때 이 패턴을 적용한다.
+
+## Verdict 분기
+
+| Verdict | 기본 옵션 |
+|---------|----------|
+| **PASS** | A) 변경 요청 → 재호출, B) 승인 → 다음 단계 |
+| **CONDITIONAL** | A) 변경 요청 → 재호출, B) 승인 → 다음 단계 (수정 권장) |
+| **FAIL** | A) 리뷰 이슈 수정 → 재호출, B) 승인 → 다음 단계 |
+
+## 확장 옵션 (오케스트레이터별 선택)
+
+기본 A/B 외에 오케스트레이터가 필요에 따라 추가할 수 있는 옵션:
+
+| 옵션 | 용도 | 사용처 |
+|------|------|--------|
+| **C) 오버라이드** | FAIL/CONDITIONAL 이슈를 인지하고 현재 상태로 진행. 사유를 devflow-audit에 기록 | construction-orchestrator code-plan 게이트 |
+| **S) 리뷰 스킵** | 리뷰어 이슈를 무시하고 진행. audit 기록됨, 다음 단계는 정상 리뷰 | construction-orchestrator code-generation 게이트 |
+| **R) 리뷰 모드 변경** | R1/R2/Ra 등 다른 리뷰 모드로 재실행 | inception-orchestrator application-design 게이트 |
+
+## 리뷰 루프 제한
+
+- 최대 5회 re-dispatch (conventions 리뷰 루프 규약 참조)
+- 5회 초과 시 conventions escalation 메시지 표시
+
+## 오버라이드 audit 형식
+
+C(오버라이드) 선택 시 devflow-audit에 기록:
+
+```
+[timestamp] review-override: [gate-name] — [사용자 사유]
+  issues-acknowledged: [리뷰 이슈 목록]
+```

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -57,36 +57,8 @@ units-generation (조건부) → [units 게이트]
 devflow-state의 `## Completed Units`에 완료 unit이 있는 경우에만 실행.
 신규 세션(완료 unit 없음)에서는 스킵.
 
-<!-- 재검증 프로토콜: _shared/patterns/session-continuity.md 참조 -->
-
-1. 직전 완료 unit의 테스트 실행
-2. 결과 분기:
-
-**통과 시:**
-```
-✅ 재검증 통과 — [unit-name] 테스트 [N]개 통과
-다음 작업부터 재개합니다.
-```
-→ Step 2로 진행
-
-**실패 시:**
-```
-⚠️ 재검증 실패 — [unit-name] 테스트 [N]개 중 [M]개 실패
-
-A) 전체 테스트 스위트 실행 (회귀 범위 확인)
-B) systematic-debugging으로 즉시 조사
-```
-→ A: 전체 실행 후 실패 있으면 debugging 라우팅
-→ B: 바로 `aidlc-systematic-debugging` 호출
-→ debugging Return 수신 후 재검증 재실행 (Step 1.5 반복, 최대 2회)
-
-**재검증 최대 횟수**: 재검증→debugging→재검증 루프는 **최대 2회**까지. 2회 실패 시 에스컬레이션:
-```
-⚠️ 재검증 2회 실패 — 자동 복구 불가
-
-A) 수동으로 디버깅 계속
-B) 재검증 건너뛰고 다음 unit 진행 (devflow-state에 "재검증 실패 미해결" 기록)
-```
+`_shared/patterns/session-continuity.md` 섹션 4 "태스크 재검증 프로토콜" 적용.
+통과 시 Step 2로 진행. 실패 시 프로토콜의 분기(debugging 라우팅 / 에스컬레이션) 따름.
 
 ### Step 2: 스테이지 결정
 

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -179,39 +179,13 @@ B) 승인, 코드 생성 진행
 <!-- @gate-option: B -> code-generation-generate -->
 <!-- @gate-option: C -> code-generation-generate {override} -->
 
-리뷰 결과에 따라 게이트 분기가 달라진다:
+`_shared/patterns/review-gate-pattern.md` 적용. 리뷰 결과에 따라 게이트 분기:
 
-**리뷰 PASS / 리뷰 없음 (Minimal depth):**
-```
-[code-generation Plan 결과 표시]
-[리뷰 결과 표시 (Standard 이상)]
-A) 변경 요청 (예: 구현 계획 수정, 접근 방식 변경 등) → code-generation 재호출
-B) 승인, 코드 생성 진행 → code-generation: GENERATE 호출
-```
+- A) 변경 요청 → code-generation 재호출
+- B) 승인 → code-generation: GENERATE 호출
+- 확장 옵션: C) 오버라이드 (FAIL/CONDITIONAL 시, review-gate-pattern의 오버라이드 audit 형식 적용)
 
-**리뷰 FAIL / CONDITIONAL:**
-```
-[code-generation Plan 결과 표시]
-[리뷰 결과 — Verdict: FAIL/CONDITIONAL + 이슈 목록 표시]
-A) 리뷰 이슈 수정 요청 → code-generation 재호출
-B) 수정 후 승인, 코드 생성 진행 → code-generation: GENERATE 호출
-C) 리뷰 이슈를 인지하고 현재 상태로 진행 (오버라이드) → code-generation: GENERATE 호출
-```
-
-C 선택 시:
-1. 사용자에게 오버라이드 사유 입력을 요청한다
-2. devflow-audit에 override 이벤트 기록:
-   ```
-   - timestamp: [ISO 8601]
-   - type: override
-   - gate: code-plan
-   - review-verdict: [FAIL|CONDITIONAL]
-   - reason: [사용자 입력 사유]
-   - issues-acknowledged: [리뷰 이슈 목록]
-   ```
-3. code-generation: GENERATE 호출로 진행
-
-리뷰 결과가 FAIL/CONDITIONAL로 반환될 때마다 C 옵션을 포함하여 게이트를 표시한다. 리뷰 루프 5회 소진 시에는 conventions escalation 메시지가 우선한다.
+리뷰 루프 5회 소진 시 conventions escalation 메시지 우선.
 
 #### 2c. code-generation Generate 호출
 
@@ -222,13 +196,11 @@ C 선택 시:
 <!-- @gate-option: A -> code-generation-generate {재호출} -->
 <!-- @gate-option: B -> next-unit -->
 <!-- @gate-option: S -> next-unit {skip-review} -->
-```
-[code-generation 완료 결과 표시]
-[리뷰 결과 표시 — Verdict: PASS/CONDITIONAL/FAIL (Standard 이상, 자동 실행)]
-A) 변경 요청 (예: 구현 방식, 테스트 범위, 에러 핸들링 등) → code-generation: GENERATE 재호출
-B) 승인, 다음 unit 진행
-S) 리뷰어 이슈를 무시하고 진행 (audit 기록됨, 다음 unit은 정상 리뷰)
-```
+`_shared/patterns/review-gate-pattern.md` 적용:
+
+- A) 변경 요청 → code-generation: GENERATE 재호출
+- B) 승인, 다음 unit 진행
+- 확장 옵션: S) 리뷰 스킵 (audit 기록됨, 다음 unit은 정상 리뷰)
 
 **리뷰 자동 실행 (인라인 모드, Standard 이상)**: `aidlc-requesting-code-review`를 R1(단일 리뷰) 모드로 자동 호출.
 Council/Teams 리뷰를 원하면 자유 발화로 요청 → Interrupt Handler가 처리.

--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -362,13 +362,10 @@ R) 리뷰 요청
 1. `_shared/reviewers/artifact-reviewer-prompt.md`를 서브에이전트로 dispatch
    - 리뷰 대상: `devflow-docs/inception/application-design.md`
    - 참조 컨텍스트: `requirements.md`, `nfr-requirements.md` (있으면), `workspace.md`
-2. 리뷰 결과를 게이트에 포함하여 재표시:
-   ```
-   [리뷰 결과 표시]
-   A) 리뷰 반영하여 수정 → application-design: DETAIL 재호출
-   B) 리뷰 참고, 현재 상태로 승인 → INCEPTION 완료
-   ```
-3. conventions 리뷰 루프 규약 적용 (Issues → 수정 권장, Recommendations → 참고)
+2. `_shared/patterns/review-gate-pattern.md` 적용:
+   - A) 리뷰 반영하여 수정 → application-design: DETAIL 재호출
+   - B) 승인 → INCEPTION 완료
+   - 확장 옵션: R) 리뷰 모드 변경
 
 **R2/Ra 선택 시 (Council 리뷰):**
 1. `_shared/patterns/council-cli-detection.md` 절차 실행:
@@ -383,19 +380,9 @@ R) 리뷰 요청
    - council-lite 시: 병합 프롬프트 사용 (1개 AI가 두 관점 수행)
 3. 결과 저장: `devflow-docs/inception/design-review-raw/{codex,gemini,synthesis}.md`
 4. Claude 의장이 개별 결과를 읽고 synthesis.md 작성 (충돌 해결 4단계 적용)
-5. **synthesis 결과를 사용자에게 표시 + 승인 대기**:
-   ```
-   [Council 리뷰 결과]
-   Gate Decision: [PASS|CONDITIONAL|FAIL]
-   Rationale: [판정 근거]
-
-   Consensus: [합의 사항]
-   Divergence: [충돌 + 의장 판정]
-   Action Items: [수정 항목]
-
-   A) 리뷰 반영하여 수정 → application-design: DETAIL 재호출
-   B) 현재 상태로 승인 → INCEPTION 완료
-   ```
+5. synthesis 결과를 `_shared/patterns/review-gate-pattern.md` 적용하여 게이트 제시:
+   - A) 리뷰 반영하여 수정 → application-design: DETAIL 재호출
+   - B) 현재 상태로 승인 → INCEPTION 완료
 
 **DETAIL 호출 시 NFR Design 활성화 판단:**
 3가지 조건 모두 충족 시 인라인 신호 추가:


### PR DESCRIPTION
## Summary
- **review-gate 패턴 추출**: 3곳(inception app-design, construction code-plan, code-generation)에서 반복되던 Verdict 분기 로직을 `_shared/patterns/review-gate-pattern.md`로 SSoT 추출. 오케스트레이터는 패턴 참조 + 고유 확장 옵션만 명시
- **revalidation 패턴 참조**: construction-orchestrator Step 1.5의 35줄 인라인 재검증 로직을 `session-continuity.md` 섹션 4 참조 3줄로 교체

## Test plan
- [x] 278 기존 테스트 전체 PASS
- [x] gate annotation 변경 없음 — 그래프 구조 영향 없음
- [x] review-gate-pattern.md에 Override/Skip/Review mode 확장 옵션 문서화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)