### PR TITLE
feat: Brownfield Stub Blind Spot Phase 1 — Stub Scan + 잔존 검증 (closes #147)

### DIFF
--- a/skills/aidlc-build-and-test/SKILL.md
+++ b/skills/aidlc-build-and-test/SKILL.md
@@ -54,9 +54,53 @@ Execute build and full test suite after all units are implemented, then generate
    - `pom.xml` → `mvn test`
 2. **전체 테스트 실행** (unit 테스트 + 통합 테스트 포함)
 3. 결과 파싱:
-   - **전체 통과** → Step 4로
+   - **전체 통과** → Step 3.5로
    - **실패 있음** → 실패 테스트 목록 포함하여 Return
      "⚠️ [N]개 테스트 실패. systematic-debugging 권장."
+
+### Step 3.5: Stub 잔존 검증 (Brownfield 전용)
+
+construction-orchestrator가 호출 시 `"Brownfield: true"` 인라인 전달한 경우에만 실행. 미전달 시 스킵하고 Step 4로.
+
+1. Stub Scan과 동일 패턴으로 프로젝트 루트 스캔
+2. 변경 파일 목록 추출:
+   - `devflow-state.md`의 `## Worktree` → `branch` 확인
+   - 워크트리 있음: `git diff --name-only main...HEAD`
+   - 워크트리 없음: `git diff --name-only $(git merge-base HEAD origin/main)...HEAD`
+   - diff 결과 비어있으면: `"⚠️ 변경 파일 감지 불가. A) 수동 지정 / B) 전체 스캔"`
+3. stub 스캔 결과와 변경 파일 교차 비교 — 변경 파일 내 stub만 추출
+
+**관련 stub 없음:**
+```
+✅ Stub 잔존 검증 통과 — 변경 파일 내 미구현 stub 없음
+```
+→ Step 4로 진행
+
+**관련 stub 발견 시 — 조건부 게이트:**
+```
+⚠️ Stub 잔존 발견 — 변경 파일 내 미구현 stub [N]건
+
+| 파일 | 라인 | 내용 |
+|------|------|------|
+| [파일경로] | [라인] | [stub 내용] |
+
+A) stub 수정 후 build-and-test 재실행
+B) stub을 인지하고 진행 → 사유 입력 요청
+```
+
+**A 선택 시:** 사용자가 stub 수정 → build-and-test 재실행 (Step 2부터)
+**B 선택 시:** 사유 입력 요청 후, session-summary `## Deferred Stubs` 구조화 테이블에 기록:
+
+```markdown
+## Deferred Stubs
+| 파일:라인 | stub 내용 | 사유 | 관련 unit | 예상 해결 시점 |
+|-----------|----------|------|----------|--------------|
+```
+
++ devflow-audit에 `"stub-deferred: [파일:라인] — [사유]"` 기록
++ 다음 세션 재개 시 construction-orchestrator가 `## Deferred Stubs`를 감지하여 Stub Scan에 포함
+
+**스캔 실패 시:** 재시도/스킵 게이트 + devflow-audit에 `"stub-scan-error"` 기록
 
 ### Step 4: 지침 문서 생성
 

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -222,6 +222,8 @@ requesting-code-review가 모든 리뷰 로직을 소유한다 (Single Source of
 
 ### 3. build-and-test
 
+workspace.md에서 brownfield로 확인된 경우, 호출 시 인라인 전달: `"Brownfield: true"` — stub 잔존 검증 활성화. Greenfield인 경우 전달하지 않음.
+
 `aidlc-build-and-test` 호출
 
 #### 3a. Auto-fix 전처리 (Self-Healing Loop)

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -40,7 +40,8 @@ units-generation (조건부) → [units 게이트]
 - `devflow-docs/inception/requirements.md` — 요구사항 맥락 복원
 - `devflow-docs/inception/application-design.md` — 설계 맥락 복원 (있으면)
 - `devflow-docs/inception/units.md` — unit 목록 (있으면)
-- `devflow-docs/session-summary.md` — 이전 세션 맥락 (있으면)
+- `devflow-docs/inception/workspace.md` — brownfield/greenfield 여부 확인 (있으면)
+- `devflow-docs/session-summary.md` — 이전 세션 맥락 (있으면, `## Deferred Stubs` 확인)
 
 <!-- 아티팩트 로딩 규칙: _shared/patterns/session-continuity.md 참조 -->
 

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -142,9 +142,38 @@ B) 승인, 코드 생성 진행
 
 **Minimal/Standard**: 이 단계 스킵, 바로 code-generation으로.
 
+#### 2a-1. Stub Scan (Brownfield 전용)
+
+workspace.md에서 brownfield로 확인된 경우에만 실행. Greenfield는 스킵.
+
+프로젝트 루트에서 stub 패턴 스캔:
+```bash
+grep -rn "not yet implemented\|todo!()\|unimplemented!()\|NotImplementedError\|raise NotImplementedError\|UnsupportedOperationException\|TODO(\".*\")\|panic(\"not implemented\")\|panic(\"TODO\")" . --include="*.rs" --include="*.py" --include="*.ts" --include="*.java" --include="*.kt" --include="*.go" --exclude-dir=node_modules --exclude-dir=vendor --exclude-dir=.git --exclude-dir=target --exclude-dir=build --exclude-dir=__pycache__
+```
+
+**스캔 결과 처리:**
+- stub 발견 시: code-generation 호출 인라인 컨텍스트에 포함:
+  ```
+  ## Stub 교체 대상 (Brownfield)
+  아래 stub이 이 unit의 구현 범위와 관련될 수 있습니다:
+  - [파일:라인] — [stub 내용]
+  관련 stub이 있다면 실제 구현으로 교체하세요.
+  ```
+- stub 미발견 시: 전달 안 함 (무출력)
+- 스캔 실패 (exit code != 0, 1 제외) 시:
+  ```
+  ⚠️ Stub 스캔 실패 — [에러 메시지]
+  A) 재시도
+  B) 스캔 스킵 (devflow-audit에 "stub-scan-error" 기록)
+  ```
+
+세션 재개 시 `session-summary.md`의 `## Deferred Stubs`가 있으면 해당 항목도 스캔 결과에 포함하여 implementer에 전달한다.
+
+게이트: 없음 (스캔 성공 시). 스캔 실패 시만 조건부 게이트.
+
 #### 2b. code-generation Plan 호출
 
-`aidlc-code-generation` 호출 (unit명 + Complexity 인라인 전달: `"Complexity: [level]"`)
+`aidlc-code-generation` 호출 (unit명 + Complexity 인라인 전달: `"Complexity: [level]"` + Stub Scan 결과 인라인 전달)
 
 #### code-plan 게이트 [리뷰 연계 게이트 + Override 변형]
 <!-- @gate: code-plan -->


### PR DESCRIPTION
Closes #147

## Summary
- **Stub Scan (사전 인식)**: construction-orchestrator가 unit별 code-generation 호출 전 brownfield stub 패턴 스캔. 발견 시 implementer에 "교체 대상" 컨텍스트 전달. Greenfield 무영향
- **Stub 잔존 검증 (사후 검증)**: build-and-test 성공 후 변경 파일 내 잔존 stub 조건부 게이트. A) 수정 재실행 / B) Deferred Stubs 구조화 테이블 기록
- **workspace.md 컨텍스트 로드**: brownfield/greenfield 감지 기반
- **스캔 실패 처리**: scan-error 상태 + 재시도/스킵 게이트
- **Deferred Stubs 재개**: 다음 세션에서 session-summary의 deferred stub을 Stub Scan에 포함

Phase 2 (#151): CRITICAL 자동 승격 + Brownfield 체크리스트
Phase 3 (#152): Reachable stub 탐지 + Mock/Real 갭 리포트

## Test plan
- [x] 278 기존 테스트 전체 PASS
- [x] 그래프 validator 10/10 PASS (순환/dead-end/unreachable/unknown-ref)
- [x] 영향 범위 확인: construction-orchestrator + build-and-test만

🤖 Generated with [Claude Code](https://claude.com/claude-code)