### PR TITLE
ci: sync-marketplace.yml이 revision + description도 자동 sync

### DIFF
--- a/.github/workflows/sync-marketplace.yml
+++ b/.github/workflows/sync-marketplace.yml
@@ -9,9 +9,22 @@ jobs:
   sync-marketplace:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Checkout source repo (plugin.json 읽기용)
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Extract version + description + revision
+        id: meta
+        run: |
+          cd source
+          VERSION="${GITHUB_REF_NAME#v}"
+          DESCRIPTION=$(jq -r '.description' .claude-plugin/plugin.json)
+          REVISION="${GITHUB_SHA}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # plugin.json description은 1줄 규칙 유지 (workflow 단순화를 위해)
+          echo "description=${DESCRIPTION}" >> "$GITHUB_OUTPUT"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout marketplace repo
         uses: actions/checkout@v4
@@ -20,12 +33,18 @@ jobs:
           token: ${{ secrets.DEVFLOW_MARKET }}
           path: marketplace
 
-      - name: Update marketplace.json
+      - name: Update marketplace.json (version + revision + description)
         run: |
           cd marketplace
-          # jq로 aidlc 플러그인 버전만 업데이트
-          jq --arg ver "${{ steps.version.outputs.version }}" \
-            '(.plugins[] | select(.name == "aidlc")).version = $ver' \
+          jq \
+            --arg ver  "${{ steps.meta.outputs.version }}" \
+            --arg sha  "${{ steps.meta.outputs.revision }}" \
+            --arg desc "${{ steps.meta.outputs.description }}" \
+            '(.plugins[] | select(.name == "aidlc")) |= (
+              .version = $ver
+              | .revision = $sha
+              | .description = $desc
+            )' \
             .claude-plugin/marketplace.json > tmp.json \
             && mv tmp.json .claude-plugin/marketplace.json
 
@@ -37,5 +56,5 @@ jobs:
           git add .claude-plugin/marketplace.json
           # 변경이 있을 때만 커밋
           git diff --staged --quiet || \
-            git commit -m "chore: sync aidlc version to ${{ steps.version.outputs.version }}" \
+            git commit -m "chore: sync aidlc to ${{ steps.meta.outputs.version }} (revision ${{ steps.meta.outputs.revision }})" \
             && git push


### PR DESCRIPTION
## 배경

v1.10.0 릴리스 직후 marketplace 정합성 버그 발견:
- sync workflow가 marketplace의 **version 필드만** 업데이트
- `revision`, `description`은 수동 관리 → v1.8.0 시점 세팅이 stuck
- `strict: true` + stale sha → 사용자가 /plugin update 시 **v1.8.0 코드** 설치

### 영향받은 과거 릴리스

- v1.9.0 (2026-04-10): 실제로는 v1.8.0 코드
- v1.10.0 (2026-04-13): 동일 문제 — marketplace PR (devflow-marketplace#11)로 수동 수정

## 변경

`.github/workflows/sync-marketplace.yml`:

1. **source repo checkout 추가** — plugin.json에서 description 읽기 위해
2. **meta step 추가** — version / revision / description 3개를 한번에 추출
   - `version`: `${GITHUB_REF_NAME#v}` (기존)
   - `revision`: `${GITHUB_SHA}` (새로 추가)
   - `description`: `jq -r '.description' .claude-plugin/plugin.json` (새로 추가)
3. **jq update 확장** — 3 필드 함께 update (기존 version만)
4. **commit message 강화** — revision 포함 (추적성)

## 영향

- v1.11.0+ 태그 push 시 자동으로 revision + description 최신화
- v1.10.0은 별도 수동 PR로 해결

## 전제

- plugin.json의 `description`이 **1줄** 유지 (workflow 단순화). multiline 시 escape 필요 — 현 규칙 유지.

## Test plan

- [x] YAML syntax 확인 (`yamllint` / GitHub Actions 검증)
- [ ] 머지 후 다음 태그 push 시 marketplace `revision` 필드가 `GITHUB_SHA`와 일치하는지 확인
- [ ] description이 plugin.json과 동일한지 확인
- [ ] 사용자 `/plugin update aidlc` 테스트

## Follow-up

devflow-marketplace#11 머지 필요 (v1.10.0 즉시 해결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)