### PR TITLE
docs: Knowledge System Phase 1 overview + Phase 2 observation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,32 +23,13 @@ AI-DLC 방법론을 **오케스트레이터 중심 아키텍처**로 구현한 C
 
 ---
 
-## v1.10.0 — Knowledge System Phase 1
+## Recent Update
 
-본 릴리스는 **지식 시스템 레이어**를 도입합니다 (실험적, 2주 관측 중).
+### Knowledge System Phase 1 구현 (v1.10.0)
 
-| 변경 | 내용 |
-|------|------|
-| **6-type taxonomy** | Decision/Solution/Pattern/Skill/Evidence/SessionState — frontmatter overlay |
-| **Solution layer 활성화** | STORE 호출 owner를 `aidlc-systematic-debugging` 단독으로 이관 (옵션 α) |
-| **L1 ingest hook** | `hooks/post-tool-file-edit` — Edit/Write/MultiEdit/NotebookEdit 시 `devflow-docs/audit.md` 자동 append |
-| **Skill lifecycle 분류** | `skill_nature` 태깅: compensation 4 / amplification 10 / hybrid 11 / null 6 |
-| **Pattern frontmatter** | 33개 파일에 `type: pattern` + `applies_to` + `last_validated` 등 5 필드 |
+지식 시스템 레이어를 도입했습니다 (실험적, 14일 관측 중). audit 자동 누적, `systematic-debugging`의 STORE 자동 발동, 6-type taxonomy 분류 등이 추가되었으며, 사용자 즉각 효용은 제한적이고 진짜 가치는 Phase 2부터 나옵니다.
 
-### 환경 변수 (선택)
-
-| 변수 | 용도 |
-|------|------|
-| `DEVFLOW_ROOT` | MSA/multi-repo 프로젝트에서 공통 audit root 지정 (opt-in). 절대경로 + 존재 디렉토리 + 루트(`/`) 거부 검증 |
-| `DEVFLOW_HOOK_DISABLED` | 긴급 무력화 kill switch. 설정 시 hook 0.1ms 안에 exit 0 |
-
-### 관련 문서
-
-- **Rollback 가이드**: [`docs/research/knowledgesystem/rollback-guide.md`](docs/research/knowledgesystem/rollback-guide.md) — 5-level 되돌림 (Kill switch → 전체 revert → Abandon)
-- **Phase 2 baseline**: [`docs/research/knowledgesystem/phase1-baseline.md`](docs/research/knowledgesystem/phase1-baseline.md) — 트리거 T1-T10 평가 기준점 (T0 = 2026-04-14)
-- **설계 의도 + debate**: [`docs/research/knowledgesystem/handoff-context.md`](docs/research/knowledgesystem/handoff-context.md)
-
-> **관측 기간**: v1.10.0 릴리스 후 14일간 운영 데이터 수집. 2026-04-28 시점에 Phase 2 방향 결정 예정.
+자세한 내용·구현 전후 비교·관련 GitHub 이슈는 [`docs/research/knowledgesystem/phase1-overview.md`](docs/research/knowledgesystem/phase1-overview.md)를 참조하세요.
 
 ---
 

--- a/docs/research/knowledgesystem/phase1-baseline.md
+++ b/docs/research/knowledgesystem/phase1-baseline.md
@@ -28,6 +28,13 @@
 - **Sprint 1 (단기)**: 2-3일 사용 후 1차 audit.md 성장률 + Solution layer 생성 유무 확인
 - **Sprint 2 (정식)**: 14일 운영 → Phase 2 plan 작성 시점 (트리거 우선순위 결정)
 
+## 관측 대상 (Consumer Repo)
+
+Phase 1 hook은 **consumer repo**(devflow를 돌리는 업무 프로젝트)의 `devflow-docs/`에 데이터를 축적한다. Plugin repo 자체는 관측 대상이 아니며, 본 baseline은 **구현 완료 시점 참조값**이다.
+
+- **Tier 1 관측 repo**: `/Users/jay.ahn/projects/infra/nexttui` (상세: `phase2-observation-plan.md`)
+- **평가 방식**: 단일 repo OR 조건 (다중 합산 아님)
+
 ## 관측 시작일 (T0)
 
 **2026-04-13** (본 baseline 작성일).

--- a/docs/research/knowledgesystem/phase1-overview.md
+++ b/docs/research/knowledgesystem/phase1-overview.md
@@ -1,0 +1,112 @@
+# Knowledge System Phase 1 — 구현 개요와 사용자 영향
+
+> **릴리스**: aidlc-devflow v1.10.0 (2026-04-13 머지, PR #157)
+> **상태**: 실험적, 14일 관측 기간 (2026-04-13 ~ 2026-04-28)
+> **본 문서 목적**: Phase 1이 무엇을 도입했는지, 그리고 사용자 관점에서 구현 전후로 무엇이 달라지는지를 정확히 정리.
+
+---
+
+## 1. 한 줄 요약
+
+Phase 1은 **"미래 활용을 위한 데이터 수집·분류 시스템 구축"** 단계로, 사용자 즉각 효용은 audit 자동화 + STORE 자동 발동 두 가지뿐이고, 진짜 효용은 consumer repo에서 데이터가 누적되는 Phase 2부터 발생합니다.
+
+---
+
+## 2. 도입된 변경 (5건)
+
+| 변경 | 내용 |
+|------|------|
+| **6-type taxonomy** | Decision / Solution / Pattern / Skill / Evidence / SessionState — frontmatter overlay로 기존 자산 재라벨링 |
+| **Solution layer 활성화** | STORE 호출 owner를 `aidlc-systematic-debugging` 단독으로 이관 (옵션 α) |
+| **L1 ingest hook** | `hooks/post-tool-file-edit` — Edit/Write/MultiEdit/NotebookEdit 시 `devflow-docs/audit.md` 자동 append |
+| **Skill lifecycle 분류** | `skill_nature` 태깅: compensation 4 / amplification 10 / hybrid 11 / null 6 (전체 31개) |
+| **Pattern frontmatter 강화** | 33개 파일에 `type: pattern` + `applies_to` + `last_validated` 등 5 필드 |
+
+### 환경 변수 (선택)
+
+| 변수 | 용도 |
+|------|------|
+| `DEVFLOW_ROOT` | MSA/multi-repo 프로젝트에서 공통 audit root 지정 (opt-in). 절대경로 + 존재 디렉토리 + 루트(`/`) 거부 검증 |
+| `DEVFLOW_HOOK_DISABLED` | 긴급 무력화 kill switch. 설정 시 hook 0.1ms 안에 exit 0 |
+
+---
+
+## 3. 사용자 관점에서 향상된 것 (구현 전 → 후)
+
+### 3.1 자동으로 작동하는 것 (당장 체감 가능)
+
+| 영역 | 구현 전 | 구현 후 |
+|------|--------|--------|
+| **파일 수정 활동 기록** | 스킬이 의도적으로 `devflow-audit` 호출해야 기록 → 누락 빈번 | Edit/Write/MultiEdit 발생 시마다 `audit.md`에 자동 entry. 사용자/스킬 개입 0 |
+| **세션 상태 신선도** | `devflow-state.md`의 `Last Updated`가 stale 상태 자주 발생 | 모든 파일 수정 시 hook이 자동 갱신 |
+| **디버깅 지식 축적** | `systematic-debugging` 완료 후 STORE 호출이 선택적 → `solutions/`가 0건 그대로 | root_cause 확정 + fix 검증 완료 시 **무조건 STORE 발동**. `devflow-docs/solutions/{category}/<slug>.md`에 자동 누적 |
+
+### 3.2 분류·메타데이터 강화 (당장은 안 보임, 미래 효용)
+
+| 영역 | 구현 전 | 구현 후 |
+|------|--------|--------|
+| **Skill 분류** | skill 간 성격 구분 없음 (모두 동등) | 31개 skill에 `skill_nature` 부여. 모델 발전 시 어떤 skill을 경량화할지 데이터 기반 의사결정 가능 |
+| **Pattern 추적성** | pattern 파일 frontmatter 약함 (`type` / `applies_to` / `status` 부재) | 33개 파일에 `applies_to`, `status`, `last_validated` 등 표준화. stale detection / validator 도입 기반 |
+| **지식 멘탈 모델** | "이 산출물 어디 두지?" 모호 | 6-type taxonomy로 명시 (Decision은 `docs/plans/`, Solution은 `solutions/`, Pattern은 `_shared/` ...) |
+
+---
+
+## 4. 사용자가 **체감하지 못하는** 것 (정직하게)
+
+- 새로운 slash command 없음
+- 스킬 호출 패턴 동일
+- 대화 흐름 변화 없음
+- "오, 이게 편해졌네" 할 만한 직접적 UX 향상 거의 없음
+
+Phase 1은 본질적으로 **인프라 + 분류 작업**입니다. 새 명령이나 워크플로우는 추가하지 않았고, 기존 자산을 6개 유형으로 재라벨링하고 자동 데이터 누적 hook과 디버깅 지식 자동 저장 메커니즘만 추가했습니다.
+
+---
+
+## 5. 진짜 가치는 어디서 나오나 (Phase 2+)
+
+1. **Knowledge Compounding** — `solutions/`가 누적되면 systematic-debugging이 과거 사례를 자동 검색·재활용. 같은 버그를 두 번 풀지 않게 됨.
+2. **관측성** — `audit.md` 데이터로 token cost, skill 사용 패턴, gate 발동률 분석 가능 (지금 baseline 측정이 그 첫걸음).
+3. **유지보수성** — pattern frontmatter로 6개월 후 어떤 pattern이 stale인지 자동 식별.
+4. **모델 발전 대응** — `skill_nature`로 모델 자체가 잘하게 된 영역의 skill을 경량화하거나 제거하는 의사결정 가능.
+
+이래서 baseline 측정이 중요합니다 — Phase 1이 진짜 효용을 만들고 있는지(예: `solutions/`가 실제로 쌓이는지, audit이 의미 있는 신호를 주는지) **데이터로 증명해야** 다음 단계 투자를 정당화할 수 있습니다.
+
+---
+
+## 6. 관측 기간
+
+v1.10.0 릴리스 후 14일간 운영 데이터 수집. **2026-04-28 시점에 Phase 2 방향 결정 예정**.
+
+관측 대상 repo: `nexttui` (Tier 1 단일, OR 조건). 자세한 관측 설계는 [`phase2-observation-plan.md`](phase2-observation-plan.md) 참조.
+
+---
+
+## 7. 관련 GitHub 이슈 / PR
+
+### 구현 PR
+
+- [**PR #157**](https://github.com/bluejayA/aidlc-devflow/pull/157) — Knowledge System Phase 1 구현 (2026-04-13 머지, merge commit `0201e9a`). 9 commits, verify-change-1~6 PASS, pytest 273 passed, Success Signals 12/12.
+
+### 구현 이슈 (closed)
+
+- [**#154**](https://github.com/bluejayA/aidlc-devflow/issues/154) (BL-085) — Phase 1 구현 트래킹 이슈. PR #157로 closed.
+
+### 후속 작업 (post-merge follow-up, open)
+
+- [**#155**](https://github.com/bluejayA/aidlc-devflow/issues/155) (BL-086) — `aidlc-writing-plans` mapping 검증. Phase 1 Task 4에서 `applies_to` 매핑이 초기 ~10/33만 정확했던 사고의 재발 방지.
+- [**#156**](https://github.com/bluejayA/aidlc-devflow/issues/156) (BL-087) — hook 보안 가드 강화. Codex 리뷰에서 발견된 8건 중 일부는 PR #157에 흡수, 잔여 강화 작업.
+
+### 선행 / 잔여 백로그
+
+- [**#145**](https://github.com/bluejayA/aidlc-devflow/issues/145) (BL-081) — Phase 1 MVP 1, 2번 (skill_nature 분류 + STORE owner 단독화)은 본 릴리스에 흡수. **3, 4번 (Compensation Decay + validator) 잔존** — Phase 2 범위 후보.
+
+---
+
+## 8. 관련 문서
+
+- **Rollback 가이드**: [`rollback-guide.md`](rollback-guide.md) — 5-level 되돌림 (Kill switch → 전체 revert → Abandon)
+- **Phase 1 baseline (plugin repo 기준)**: [`phase1-baseline.md`](phase1-baseline.md) — 트리거 T1-T10 평가 기준점 (T0 = 2026-04-13)
+- **Phase 2 관측 설계 (consumer repo 기준)**: [`phase2-observation-plan.md`](phase2-observation-plan.md) — nexttui T0 snapshot + 재측정 명령
+- **설계 의도 + 과거 debate**: [`handoff-context.md`](handoff-context.md)
+- **6-type taxonomy 상세**: [`knowledge-taxonomy.md`](knowledge-taxonomy.md)
+- **통합 전략**: [`aidlc-knowledge-integration-plan.md`](aidlc-knowledge-integration-plan.md)

--- a/docs/research/knowledgesystem/phase2-observation-plan.md
+++ b/docs/research/knowledgesystem/phase2-observation-plan.md
@@ -1,0 +1,104 @@
+# Knowledge System Phase 2 — 관측 설계 + Consumer Baseline
+
+> **목적**: Phase 1 구현이 plugin repo에 머지된 후, 실사용 데이터가 축적되는 **consumer repo**에서 Phase 2 트리거를 평가하기 위한 관측 설계.
+>
+> **참조**: `phase1-baseline.md` (plugin repo 기준 T0), `../../plans/2026-04-13-knowledge-system-phase1-plan.md` (Phase 2 Re-evaluation Criteria)
+
+## 전략: Tier 1 단일 Consumer 관측 (OR 조건)
+
+다중 consumer 집계 대신 **대표 repo 1개에서 독립 평가**. 트리거 임계(T1-T10)는 단일 프로젝트 기준으로 설계되었으므로 합산하면 의미가 변질된다. 한 repo라도 임계 초과 = 유효 신호로 간주한다.
+
+| 구분 | Repo | 역할 |
+|------|------|------|
+| Tier 1 | `/Users/jay.ahn/projects/infra/nexttui` | 실사용 관측 — devflow 주사용 환경 |
+| 예비 | (신규 프로젝트) | nexttui 데이터 부족 시 추가 고려. 현재는 불필요 |
+
+신규 greenfield 프로젝트는 **억지로 돌리는 시뮬레이션이 될 위험**이 있어 채택하지 않음. nexttui는 이미 3주+ devflow 반복 사용 이력(archived state 12개)이 확인됨.
+
+## nexttui T0 Snapshot (관측 시작점)
+
+### 측정 시점
+
+- **날짜**: 2026-04-14T04:32:12Z (UTC)
+- **commit**: `7d13944` (branch `main`)
+- **플러그인 상태**: PR #157 plugin repo 머지 완료 (2026-04-13T23:50:13Z), **단 nexttui에는 아직 새 hook 미반영**
+
+### Baseline 값
+
+| 측정 대상 | 값 | Phase 2 트리거 임계 |
+|----------|-----|------|
+| `devflow-docs/audit.md` 크기 | **17,326 bytes** (172 lines) | T1: > 100KB → audit-log/ rotation |
+| `audit.md` file-edit prefix 건수 | **0** (v1.10.0 설치 완료. nexttui 세션에서 Edit 발생 후 누적 시작) | T10: file-edit > 80% → signal/noise 재검토 |
+| `devflow-docs/solutions/` 파일 수 | **0** | T2 (Critical): 14일 후 0 = STORE trigger 실패 분석 |
+| `devflow-state.md` | 존재 (3,028 bytes) | T9 (Critical): heading 누락/깨짐 → hook race bug |
+| `.archive/` archive 수 (정확) | state **11** + summary **3** + inception **9** + construction **5** | 정상 archive (spec 준수) |
+| `.archive/legacy/` 보존 수 | state 12 + summary 3 = **15** | Mar 24~27 구 명명규약 (`-archived-` suffix) 흔적. 측정에서 제외 |
+
+### T0 해석 (중요)
+
+- **`audit.md` 17KB는 Phase 1 hook 적용 전 수치**. plugin 업데이트가 nexttui에 반영되면 file-edit prefix가 누적되기 시작한다.
+- **`solutions/` = 0은 이미 T2 Critical 트리거 후보 신호**. 3주 이상 devflow 사용 중인데 STORE 산출물이 한 번도 생성되지 않음. Phase 2 진입 시 최우선 분석 대상.
+- **Archive 정합성 cleanup (2026-04-14)**: nexttui `devflow-docs/` 루트에 구 명명규약(`devflow-state-archived-*`, `session-summary-archived-*`) 15개가 spec 표준(`.archive/`)과 분리되어 있었음. `git mv`로 전부 `.archive/legacy/`에 이동. T9 트리거 평가 시 `.archive/` 직속(spec 준수분)만 기준으로 사용한다.
+
+## 관측 프로토콜
+
+### 전제: Plugin 업데이트 반영 확인 (2026-04-14 검증 완료)
+
+Plugin v1.10.0이 `~/.claude/plugins/cache/devflow-marketplace/aidlc/1.10.0`에 **2026-04-14T01:02:12Z 설치 완료**. Hook을 수동 실행(stdin JSON payload)해 audit.md에 entry가 정상 추가되는 것 확인했다. 로직 레벨 검증 PASS.
+
+nexttui에서 실제 Claude Code 세션이 Edit/Write를 수행하면 자동 기록된다:
+
+```bash
+cd /Users/jay.ahn/projects/infra/nexttui
+grep -c 'file-edit' devflow-docs/audit.md  # > 0 이면 E2E 확인
+```
+
+**주의**: 다른 repo에서 열린 Claude Code 세션이 nexttui 파일을 Edit해도 hook은 "outside repo"로 판단해 기록하지 않는다 (설계상 의도). 반드시 nexttui를 cwd로 한 세션이어야 한다.
+
+### 측정 시점
+
+| 시점 | 날짜 | 액션 |
+|------|------|------|
+| T0 | 2026-04-14 | 본 문서 T0 snapshot (상단 표) |
+| T0' | Hook 반영 직후 | file-edit prefix 1건 발견 시점 재측정 |
+| T+3 | 2026-04-17 | Sprint 1 1차 체크 — audit 성장률, solutions 생성 유무 |
+| T+14 | 2026-04-28 | Phase 2 plan 작성 시점 + 레드팀 3차 리뷰 호출 권장 |
+
+(원 baseline의 T+3=2026-04-16, T+14=2026-04-27은 plugin repo 기준. nexttui는 T0가 하루 늦어 조정.)
+
+### 재측정 명령
+
+```bash
+cd /Users/jay.ahn/projects/infra/nexttui
+echo "date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "commit: $(git rev-parse --short HEAD)"
+echo "audit.md size: $(wc -c < devflow-docs/audit.md) bytes"
+echo "audit.md lines: $(wc -l < devflow-docs/audit.md) lines"
+echo "file-edit count: $(grep -c 'file-edit' devflow-docs/audit.md 2>/dev/null || echo 0)"
+echo "solutions/ count: $(find devflow-docs/solutions -type f 2>/dev/null | wc -l)"
+echo "state.md present: $([ -f devflow-docs/devflow-state.md ] && echo yes || echo no)"
+# .archive/ 직속만 카운트 (legacy/ 제외)
+echo "archived states: $(find devflow-docs/.archive -maxdepth 1 -name 'devflow-state-*.md' 2>/dev/null | wc -l)"
+echo "archived summaries: $(find devflow-docs/.archive -maxdepth 1 -name 'session-summary-*.md' 2>/dev/null | wc -l)"
+echo "archived inception/: $(find devflow-docs/.archive -maxdepth 1 -name 'inception-*' -type d 2>/dev/null | wc -l)"
+echo "archived construction/: $(find devflow-docs/.archive -maxdepth 1 -name 'construction-*' -type d 2>/dev/null | wc -l)"
+```
+
+## Phase 2 평가 시 사용 방법
+
+1. 위 재측정 명령으로 **nexttui 새 값** 기록
+2. `phase1-baseline.md` 재실행으로 **plugin repo 새 값** 기록 (대조군)
+3. nexttui 값을 기준으로 T1-T10 트리거 테이블 적용 (OR 조건)
+4. Critical 트리거(T2/T9) 발동 여부 먼저 확인
+5. 새 plan 작성: `docs/plans/YYYY-MM-DD-knowledge-system-phase2-*.md`
+6. 레드팀 3차 리뷰 호출 자료:
+   - 본 관측 문서 + 재측정 결과
+   - `phase1-baseline.md` (plugin repo 기준)
+   - `handoff-context.md` (설계 의도)
+   - 트리거 발동 현황 표
+
+## 알려진 제약
+
+- **단일 repo 관측의 한계**: nexttui에 특화된 신호가 plugin 일반 문제로 해석될 위험. 특이 패턴 발견 시 "nexttui 특성인지 plugin 일반인지" 구분 필요.
+- **Hook 반영 지연**: 플러그인 marketplace 기반 업데이트 주기에 따라 T0'가 늦어질 수 있음. 이 기간의 데이터는 file-edit 기반 트리거에서 제외.
+- **Brownfield 노이즈**: nexttui는 이미 상당량의 audit/state 이력 보유. 절대값 임계(T1: 100KB)는 신규 증가분 기준으로 재해석 권장.


### PR DESCRIPTION
Refs #154

## Summary
- **신규** `docs/research/knowledgesystem/phase1-overview.md` — 구현 전후 사용자 영향 비교 + 관련 GitHub 이슈/PR 링크 정리
- **신규** `docs/research/knowledgesystem/phase2-observation-plan.md` — nexttui Tier 1 단일 관측 설계 + T0 snapshot (2026-04-14) + 단순화된 재측정 명령
- **수정** `docs/research/knowledgesystem/phase1-baseline.md` — "관측 대상 (Consumer Repo)" 섹션 추가
- **수정** `README.md` — v1.10.0 상세 섹션을 `Recent Update` + phase1-overview 링크로 단순화

## 발견 경위
nexttui Phase 2 baseline 측정 중 두 가지 이슈 확인:
1. 측정 대상이 plugin repo 자체가 아니라 **consumer repo** 라는 점을 baseline 문서가 명시하지 않음
2. 다중 consumer 집계 전략, 관측 repo 선정 기준이 미문서화

추가로 README의 v1.10.0 섹션이 길어지면서 Phase 1의 사용자 가치를 한눈에 파악하기 어려운 문제도 함께 해소.

## Test plan
- [ ] README의 phase1-overview 링크 동작 확인
- [ ] phase1-overview의 GitHub 이슈 링크 (#154/#155/#156/#145, PR #157) 동작 확인
- [ ] phase2-observation-plan의 재측정 명령이 nexttui에서 정상 실행되는지 확인 (이미 완료)