### PR TITLE
docs: graphify-inspired ideas + knowledgesystem reading map

### DIFF
--- a/docs/research/knowledgesystem/graphify-inspired-ideas.md
+++ b/docs/research/knowledgesystem/graphify-inspired-ideas.md
@@ -1,0 +1,133 @@
+# graphify 참조 차용 아이디어
+
+> **소스**: [safishamsi/graphify](https://github.com/safishamsi/graphify) — AI coding assistant skill that turns any folder into a queryable knowledge graph
+> **작성일**: 2026-04-15
+> **목적**: Phase 2 plan 작성 시 차용 여부를 판단하기 위한 후보 아이디어 정리 (참조용, 미확정)
+
+---
+
+## 1. 프로젝트 요약
+
+graphify는 `/graphify .` 한 줄로 **코드/문서/PDF/이미지/비디오를 지식 그래프로 변환**하는 Claude Code skill. 3-pass 추출(AST → Whisper → LLM subagent), Leiden community detection, EXTRACTED/INFERRED/AMBIGUOUS 태그 체계. 26k+ stars, Python 기반, 플랫폼 중립(Claude Code/Codex/Cursor/Gemini 등).
+
+핵심 출력:
+- `GRAPH_REPORT.md` — god nodes + communities + surprising connections + suggested questions
+- `graph.json` — 쿼리 가능한 persistent graph
+- `graph.html` — 인터랙티브 시각화
+- `cache/` — SHA256 기반 증분 업데이트
+
+---
+
+## 2. 차용 가치 높은 아이디어 (Phase 2 고려)
+
+### 2.1 Evidence tagging (EXTRACTED / INFERRED / AMBIGUOUS) ★★★★★
+
+**graphify 원형**: 모든 그래프 관계에 3개 태그 부여.
+- `EXTRACTED`: 소스에서 직접 발견
+- `INFERRED`: 추론 + confidence score
+- `AMBIGUOUS`: 사람 검토 필요
+
+**우리 현 상태**: Pattern frontmatter에 `source: manual | promoted_from_solution` 존재. 방향은 같으나 세밀도 부족.
+
+**차용 방안**: taxonomy의 `related` 필드에 아래 frontmatter 추가:
+```yaml
+related:
+  - path: "skills/aidlc-systematic-debugging/SKILL.md"
+    tag: EXTRACTED
+    confidence: 1.0
+  - path: "docs/research/2026-04-06-skill-lifecycle-strategy.md"
+    tag: INFERRED
+    confidence: 0.7
+    reason: "동일 BL-081 주제"
+```
+
+**ROI**: Phase 1 자산 33개 Pattern + 31개 Skill에 재라벨링 ≈ 1-2시간. 향후 graph 자동 생성 시 신뢰도 자동 반영.
+
+### 2.2 GRAPH_REPORT.md (always-on 요약 페이지) ★★★★
+
+**graphify 원형**: 한 페이지에 **god nodes**(가장 많이 참조되는 노드), **surprising connections**(예상 못한 연결), **suggested questions**를 자동 생성. Pre-read hook으로 매 세션 주입.
+
+**우리 현 상태**: 없음. 사용자가 질문해야 문서 관계 파악 가능.
+
+**차용 방안**:
+- 단기(수동): `docs/research/knowledgesystem/reading-map.md` 손으로 작성 (본 작업에서 동시 생성)
+- 중기(반자동): frontmatter `related` 필드 파싱 → Mermaid graph 자동 생성 스크립트
+- 장기(자동): Phase 2/3에서 NetworkX + 링크 파서로 GRAPH_REPORT.md 생성
+
+**ROI**: 단기는 즉시 가능. 자동화는 Phase 2 관측성 작업과 번들.
+
+### 2.3 Always-on pre-read hook ★★★★
+
+**graphify 원형**: PreToolUse hook으로 Glob/Grep 전에 `GRAPH_REPORT.md` 주입. *"grep하지 말고 graph로 navigate하라"*.
+
+**우리 현 상태**: `hooks/session-start`는 SessionStart에만 작동. Grep/Glob 전 주입 없음.
+
+**차용 방안**: 기존 `session-start` hook이 `devflow-state.md` + `reading-map.md` summary 함께 주입. 또는 PreToolUse hook 추가.
+
+**ROI**: 기존 hook 확장이라 비용 낮음. Phase 2 관측 후 유효성 데이터 확보한 뒤 결정.
+
+### 2.4 `.devflowignore` (gitignore syntax 필터) ★★★
+
+**graphify 원형**: `.graphifyignore`로 그래프 포함·제외 경로 사용자 커스터마이징.
+
+**우리 현 상태**: `hooks/post-tool-file-edit`의 whitelist/exclusion이 **hardcoded**.
+```bash
+# whitelist: devflow-docs/*|docs/*|skills/*|CLAUDE.md|README.md
+# exclusion: tests/*|hooks/*|.claude-plugin/*|.git/*|.worktrees/*|devflow-docs/.archive/*|...
+```
+
+**차용 방안**: `.devflowignore` 파일로 빼내면 프로젝트별 커스터마이징 가능. nexttui 같은 consumer repo가 자체 규약 추가 가능.
+
+**ROI**: 사용자 커스터마이징 요구가 쌓일 때 도입. 현재는 YAGNI.
+
+---
+
+## 3. 차용 가치 낮은 아이디어 (overkill / 범위 밖)
+
+| 아이디어 | 이유 |
+|---------|------|
+| Leiden community detection | Phase 3 shared-tier 승격 판정에 쓰일 수 있으나, 현재 자산 규모(~60개)에서는 단순 `applies_to` 그룹핑으로 충분 |
+| Whisper 멀티모달 (video/audio) | aidlc 맥락과 무관 |
+| SHA256 cache 증분 업데이트 | 우리는 hook이 실시간 집계 → SHA256 캐시 불필요 |
+| MCP 서버 exposure | Phase 3+ 고려 |
+| 플랫폼 중립 (Cursor / Gemini / Codex) | aidlc는 Claude Code 전용 설계. 장기 확장 여지 |
+| 3-pass extraction pipeline | 우리 자산은 Markdown + frontmatter 중심이라 AST/Whisper 불필요 |
+
+---
+
+## 4. 공통 철학 포인트 (간접 검증)
+
+graphify와 우리 knowledge system은 설계 철학이 놀라울 만큼 수렴:
+
+| 철학 | graphify | aidlc-devflow |
+|------|----------|---------------|
+| **Embeddings 없이 충분** | Leiden community (graph topology) | Frontmatter overlay (manual classification) |
+| **결정적 parser 먼저, LLM 나중** | AST pass → Whisper → Claude subagent | Frontmatter 분류 → 필요 시 수동 review |
+| **정직성 태그** | EXTRACTED / INFERRED / AMBIGUOUS | (지금은 `source`만, 확장 후보) |
+| **증분 처리** | SHA256 cache | post-tool-file-edit hook의 append-only audit |
+| **한 페이지 요약 + deep query** | GRAPH_REPORT.md + `query`/`path`/`explain` | (지금 없음, 차용 후보) |
+
+**해석**: graphify가 5개월 앞서 26k stars를 받은 방향과 우리가 독립적으로 도달한 방향이 일치 → *"우리가 가는 길이 맞다"* 는 간접 검증이자, **아직 구현 안 된 차용 후보들이 우리 로드맵의 빈 칸을 정확히 채움**.
+
+---
+
+## 5. Phase 2 진입 시 의사결정 체크리스트
+
+Phase 2 plan 작성 시 아래 항목 검토:
+
+- [ ] **§2.1 Evidence tagging 확장**: 기존 `source` 필드 → `related` 필드 확장으로 트리거 가능? 비용 vs 효용 측정.
+- [ ] **§2.2 GRAPH_REPORT 자동 생성**: 수동 reading-map 운영 경험 기반으로 자동화 여부 판단.
+- [ ] **§2.3 Pre-read hook 확장**: baseline 관측에서 "문서 간 이동 비용" 신호가 잡히는지 먼저 확인.
+- [ ] **§2.4 .devflowignore**: 사용자(nexttui 등 consumer) 요청 누적 기준 트리거.
+
+---
+
+## 6. 참고
+
+- **graphify repo**: https://github.com/safishamsi/graphify
+- **언급된 원문**: `aidlc-devflow-context-v2.1.md` §8 "참고 자료" — 초기부터 참조 프로젝트 중 하나로 식별됨
+- **관련 내부 문서**:
+  - [`knowledge-taxonomy.md`](knowledge-taxonomy.md) — 현재 `source` 필드 정의 위치
+  - [`phase1-overview.md`](phase1-overview.md) — Phase 1 구현 완료 상태
+  - [`phase2-observation-plan.md`](phase2-observation-plan.md) — 관측 설계
+  - [`reading-map.md`](reading-map.md) — 본 제안 §2.2의 수동 첫걸음

--- a/docs/research/knowledgesystem/reading-map.md
+++ b/docs/research/knowledgesystem/reading-map.md
@@ -1,0 +1,168 @@
+# Knowledge System — Reading Map
+
+> **목적**: 현재 `docs/research/knowledgesystem/` 아래 문서들의 생성 순서·역할·참조 관계를 한눈에 파악하기 위한 **수동 네비게이션 맵**.
+> **상태**: 임시 수동 버전. 향후 자동 생성(Mermaid/GRAPH_REPORT 자동화)으로 대체 예정 — `graphify-inspired-ideas.md` §2.2 참조.
+> **최종 갱신**: 2026-04-15
+
+---
+
+## 1. 목적별 빠른 진입점
+
+| "이것이 궁금하다면..." | 먼저 읽을 문서 |
+|----------------------|--------------|
+| Phase 1이 뭘 했는지 사용자 관점 요약 | [`phase1-overview.md`](phase1-overview.md) |
+| 왜 이렇게 설계했는지 (debate 이력) | [`handoff-context.md`](handoff-context.md) |
+| 6-type 분류가 정확히 무슨 뜻인지 | [`knowledge-taxonomy.md`](knowledge-taxonomy.md) |
+| 통합 전략 (A+C 하이브리드) 전체 그림 | [`aidlc-knowledge-integration-plan.md`](aidlc-knowledge-integration-plan.md) |
+| Phase 2 평가를 시작할 준비 | [`phase2-observation-plan.md`](phase2-observation-plan.md) |
+| 뭔가 잘못됐을 때 되돌림 | [`rollback-guide.md`](rollback-guide.md) |
+| 다음 단계 아이디어 후보 (graphify 차용) | [`graphify-inspired-ideas.md`](graphify-inspired-ideas.md) |
+
+---
+
+## 2. 생성 순서 (timeline)
+
+| 생성일 | 문서 | 배경 |
+|--------|------|------|
+| **2026-04-13** (Phase 1 설계일) | `aidlc-devflow-context-v2.1.md` | 설계 컨텍스트 스냅샷 (v1.9.0 기준 자산 현황) |
+| 2026-04-13 | `PROMPT-claude-code-knowledge-integration.md` | 레드팀 프롬프트 (설계 제약 주입용) |
+| 2026-04-13 | `SPEC-knowledge-layer-sprint1-v0.3.md` | 초기 사양 (이후 integration-plan으로 수렴) |
+| 2026-04-13 | `NOTE-knowledge-tier-multi-team-sprint3.md` | Sprint 3+ 멀티팀 티어 아이디어 (Phase 1 범위 밖) |
+| 2026-04-13 | `knowledge-taxonomy.md` ★ | **6-type taxonomy 확정** |
+| 2026-04-13 | `aidlc-knowledge-integration-plan.md` ★ | **통합 전략 (A+C)** |
+| 2026-04-13 | `executable-next-steps.md` | Change 1-6 실행 상세 |
+| 2026-04-13 | `handoff-context.md` | 설계 의도 + debate 보존 |
+| **2026-04-13 23:36** (구현 직후) | `phase1-baseline.md` | plugin repo T0 측정 |
+| **2026-04-14 08:37** | `rollback-guide.md` | 5-level 되돌림 절차 |
+| **2026-04-15 09:11** (PR #163 머지) | `phase1-overview.md` ★ | **구현 완료 후 사용자 영향 요약** |
+| 2026-04-15 09:11 | `phase2-observation-plan.md` ★ | **consumer repo(nexttui) 관측 설계** |
+| **2026-04-15** (본 문서 + 동시 작성) | `graphify-inspired-ideas.md` | Phase 2+ 차용 아이디어 |
+| 2026-04-15 | `reading-map.md` | (본 문서) |
+
+(★ = 주요 진입점)
+
+---
+
+## 3. 역할 분류
+
+### 3.1 설계 단계 (Phase 1 INCEPTION)
+
+> 무엇을 만들지 결정한 근거. **Phase 1 완료 후 역사적 레퍼런스**로만 참조.
+
+- `aidlc-devflow-context-v2.1.md` — 설계 시점 자산 현황 스냅샷
+- `PROMPT-claude-code-knowledge-integration.md` — 레드팀 제약 주입용 prompt
+- `SPEC-knowledge-layer-sprint1-v0.3.md` — 초기 사양 (integration-plan에 흡수됨)
+- `NOTE-knowledge-tier-multi-team-sprint3.md` — Sprint 3+ 범위 외 아이디어 메모
+
+### 3.2 확정 설계 (Phase 1 CONSTRUCTION 근거)
+
+> 구현이 이 문서를 근거로 이루어짐. **재구현/롤백 시 재참조**.
+
+- `knowledge-taxonomy.md` — 6-type 분류 정의 ★
+- `aidlc-knowledge-integration-plan.md` — 통합 전략 + 디렉토리 구조 ★
+- `executable-next-steps.md` — Change 1-6 실행 상세 patch
+- `handoff-context.md` — 왜 그 선택을 했는지 (debate 보존)
+
+### 3.3 구현 완료 후 (Phase 2 진입 필수)
+
+> Phase 2 재평가 절차의 **측정 기준점 + 실행 자료**.
+
+- `phase1-overview.md` — 구현 전후 사용자 영향 요약 (진입점) ★
+- `phase1-baseline.md` — plugin repo T0 = 2026-04-13
+- `phase2-observation-plan.md` — consumer repo nexttui T0 = 2026-04-14, 재측정 명령 ★
+- `rollback-guide.md` — 5-level 되돌림 (Kill switch → 전체 revert → Abandon)
+
+### 3.4 미래 방향 (Phase 2 plan 작성 시 참조)
+
+- `graphify-inspired-ideas.md` — 차용 후보 (Evidence tagging / GRAPH_REPORT / pre-read hook 등)
+- `reading-map.md` — (본 문서, 수동 네비게이션)
+
+---
+
+## 4. 의존 관계 (무엇을 읽으려면 무엇을 먼저?)
+
+```
+aidlc-devflow-context-v2.1        [설계 시점 현황]
+        │
+        ├─► knowledge-taxonomy ◄── PROMPT-claude-code-knowledge-integration
+        │            │               (레드팀 제약 주입)
+        │            ▼
+        └─► aidlc-knowledge-integration-plan
+                     │
+                     ├─► executable-next-steps
+                     │         │
+                     │         ▼
+                     │   [PR #157 구현]
+                     │         │
+                     │         ▼
+                     ├─► phase1-baseline (plugin repo T0)
+                     │         │
+                     │         ▼
+                     ├─► rollback-guide
+                     │
+                     └─► handoff-context ◄── (Phase 2 평가 시 필수)
+                               │
+                               ▼
+                         phase1-overview (사용자 영향 요약)
+                               │
+                               ▼
+                         phase2-observation-plan (consumer repo nexttui T0)
+                               │
+                               ▼
+                         graphify-inspired-ideas (차용 후보)
+                               │
+                               ▼
+                         [Phase 2 plan 작성 — 미완]
+
+SPEC-knowledge-layer-sprint1-v0.3  [흡수됨, history]
+NOTE-knowledge-tier-multi-team-sprint3  [Sprint 3+, 범위 외]
+```
+
+### 핵심 Reading Path
+
+**신규 참여자 (Phase 1 전체 이해)**:
+1. `phase1-overview.md` — 사용자 관점 요약
+2. `handoff-context.md` — 왜 이렇게?
+3. `knowledge-taxonomy.md` — 분류 체계
+4. `aidlc-knowledge-integration-plan.md` — 전체 전략
+
+**Phase 2 평가자**:
+1. `docs/plans/2026-04-13-knowledge-system-phase1-plan.md` §Phase 2 Re-evaluation Criteria
+2. `phase2-observation-plan.md` — 재측정 명령
+3. `phase1-baseline.md` — T0 비교
+4. `handoff-context.md` — 원설계 의도 복원
+5. `graphify-inspired-ideas.md` — 새 아이디어 후보
+
+**Rollback 결정자**:
+1. `rollback-guide.md` — 5-level 절차
+2. `phase1-overview.md` §구현된 변경 — 되돌릴 범위 파악
+3. `handoff-context.md` §기각된 대안 — 대체 경로 확인
+
+---
+
+## 5. 외부 연결 (knowledgesystem/ 밖)
+
+| 대상 | 역할 |
+|------|------|
+| [`docs/plans/2026-04-13-knowledge-system-phase1-plan.md`](../../plans/2026-04-13-knowledge-system-phase1-plan.md) | Phase 1 실행 plan (이 문서들의 실제 구현 계획) |
+| [`docs/research/2026-04-06-skill-lifecycle-strategy.md`](../2026-04-06-skill-lifecycle-strategy.md) | BL-081 skill_nature 분류의 원설계 |
+| [PR #157](https://github.com/bluejayA/aidlc-devflow/pull/157) | Phase 1 구현 (2026-04-13 merged) |
+| [PR #163](https://github.com/bluejayA/aidlc-devflow/pull/163) | phase1-overview + phase2-observation-plan 작성 |
+| [PR #164](https://github.com/bluejayA/aidlc-devflow/pull/164) | plan 문서에 신규 docs 참조 링크 추가 |
+| [Issue #154 (BL-085)](https://github.com/bluejayA/aidlc-devflow/issues/154) | Phase 1 구현 트래킹 (closed) |
+| [Issue #145 (BL-081)](https://github.com/bluejayA/aidlc-devflow/issues/145) | skill_nature 1,2번 흡수. 3,4번 잔존 |
+| [Issue #155 (BL-086)](https://github.com/bluejayA/aidlc-devflow/issues/155) | aidlc-writing-plans mapping 검증 (후속) |
+| [Issue #156 (BL-087)](https://github.com/bluejayA/aidlc-devflow/issues/156) | hook 보안 가드 강화 (후속) |
+
+---
+
+## 6. 갱신 정책
+
+본 문서는 **수동 유지**. 새 문서 추가·삭제 시 함께 갱신. 자동화는 Phase 2에서 `graphify-inspired-ideas.md` §2.2 의사결정 후 결정.
+
+**갱신 트리거**:
+- 신규 knowledgesystem 문서 생성
+- 문서 삭제 또는 대체
+- Phase 2 plan 작성 완료 (당시 시점 스냅샷 포함)
+
+stale 위험 수용. 주요 진입점(★ 표시 4개) 중 하나라도 틀리면 먼저 수정.


### PR DESCRIPTION
Refs #154

## Summary
2 new docs under `docs/research/knowledgesystem/`:

1. **`graphify-inspired-ideas.md`** — [safishamsi/graphify](https://github.com/safishamsi/graphify) (26k+ stars) 참조 프로젝트에서 Phase 2+ 차용 후보 정리
   - 우선순위 ★★★★★ Evidence tagging (EXTRACTED/INFERRED/AMBIGUOUS)
   - 우선순위 ★★★★ GRAPH_REPORT 요약 페이지
   - 우선순위 ★★★★ Always-on pre-read hook
   - 우선순위 ★★★ `.devflowignore` 파일
   - Overkill 판정: Leiden clustering / Whisper 멀티모달 / MCP / 플랫폼 중립

2. **`reading-map.md`** — knowledgesystem/ 13개 문서의 수동 네비게이션 맵
   - 목적별 빠른 진입점
   - 생성 순서 (timeline)
   - 설계/확정/구현완료/미래 4분류
   - 의존 관계 ASCII 다이어그램
   - Reading path (신규 참여자 / Phase 2 평가자 / Rollback 결정자)
   - 외부 PR/Issue 연결

## 발견 경위
Jay의 두 질문:
- "문서 간 연관관계를 그래프로 보면 도움될까?"
- "graphify에서 차용할 아이디어는?"

→ graphify가 우리 Phase 2+ 방향과 정확히 수렴함을 재확인. 수동 reading-map을 graphify의 `GRAPH_REPORT.md` 수동 첫걸음 버전으로 구현.

## Test plan
- [ ] reading-map의 모든 로컬 링크 동작 확인
- [ ] reading-map의 외부 PR/Issue 링크 동작 확인
- [ ] graphify-inspired-ideas의 graphify repo 링크 동작 확인