### PR TITLE
feat(skills): Memory Sync Reconciliation MVP (BL-092)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aidlc",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "AI-DLC 방법론 기반 개발 워크플로우 플러그인 (Orchestrator-Centric, Knowledge System Phase 1: 6-type taxonomy + Solution layer live + L1 ingest hook, skill_nature 분류 comp 4/amp 10/hybrid 11/null 6, Pattern 33 frontmatter, DEVFLOW_ROOT MSA opt-in, 28개 skill + 3개 유틸리티, 17개 공유 패턴, 12개 리뷰어, 5개 에이전트, 4-stage 코드 리뷰 Distrust by Default, 273개 테스트)",
   "skills": "./skills"
 }

--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -12,6 +12,7 @@
 - **BL-086**: aidlc-writing-plans에 mapping/매핑 검증 단계 추가 — Task 4 사고 재발 방지 [P2] [#155](https://github.com/bluejayA/aidlc-devflow/issues/155)
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
+- **BL-092**: Memory Sync Reconciliation MVP — finishing 스킬 + using-devflow staleness check (BL-091 자매, refs #176) [P2] [#177](https://github.com/bluejayA/aidlc-devflow/issues/177)
 
 > BL-085 (Knowledge System Phase 1)는 구현 완료 후 본 파일에서 제거 (git history로 추적).
 > Baseline + Phase 2 trigger 평가 기준: `docs/research/knowledgesystem/phase1-baseline.md` 참조.

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -142,7 +142,7 @@ git worktree prune
 
 → "동기화" / "건너뛰기"
 
-"동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
 > 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
 
@@ -217,7 +217,7 @@ devflow는 PR 머지 후 종료 처리됩니다.
 
 → "동기화" / "건너뛰기"
 
-"동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
 > 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
 

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -142,7 +142,7 @@ git worktree prune
 
 → "동기화" / "건너뛰기"
 
-"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/` — `<dashed-cwd>`는 절대 cwd의 `/`를 `-`로 치환한 형태. 예: `/Users/jay/project` → `-Users-jay-project`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. 후보 디렉토리가 2개 이상 매치되면 업데이트를 중단하고 사용자 확인을 요청한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
 **실행 기록** (이 프롬프트가 표시되면 `devflow-docs/audit.md`에 한 줄 append):
 `[<ISO timestamp>] memory-sync-reconciliation-prompted | option=<A|B> | choice=<sync|skip>`
@@ -218,7 +218,7 @@ devflow는 PR 머지 후 종료 처리됩니다.
 
 → "동기화" / "건너뛰기"
 
-"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+"동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/` — `<dashed-cwd>`는 절대 cwd의 `/`를 `-`로 치환한 형태. 예: `/Users/jay/project` → `-Users-jay-project`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. 후보 디렉토리가 2개 이상 매치되면 업데이트를 중단하고 사용자 확인을 요청한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
 **실행 기록** (이 프롬프트가 표시되면 `devflow-docs/audit.md`에 한 줄 append):
 `[<ISO timestamp>] memory-sync-reconciliation-prompted | option=<A|B> | choice=<sync|skip>`

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -144,6 +144,8 @@ git worktree prune
 
 "동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
+> 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
+
 <!-- @state-update: 옵션 A 완료 → Current Phase를 finished로 -->
 **devflow 종료 처리** (devflow-state.md가 존재하는 경우):
 1. `devflow-docs/devflow-state.md`의 `## Current Phase`를 `finished`로 업데이트
@@ -216,6 +218,8 @@ devflow는 PR 머지 후 종료 처리됩니다.
 → "동기화" / "건너뛰기"
 
 "동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+
+> 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
 
 <!-- @state-update: 옵션 B PR 생성 → Finishing Choice + PR URL 기록 -->
 **devflow state 유지**: 옵션 B에서는 devflow-state.md를 아카이브하지 않는다. PR 머지 후 다음 세션에서 using-devflow가 PR 머지 확인 → 종료 처리를 안내한다. devflow-state에 `## Finishing Choice`를 `B (PR pending)` + `## PR URL`을 `[github-pr-url]`로 기록한다.

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -132,6 +132,18 @@ git worktree prune
 ```
 사용자가 "정리"를 선택하면 파일을 열어 함께 정리한다. "건너뛰기"하면 그대로 진행한다.
 
+**Memory Sync Reconciliation** (프로젝트 auto-memory 갱신 필요 여부 확인):
+
+이번 사이클 결과가 auto-memory에 반영돼야 하는지 점검한다. 하나라도 해당되면 "동기화"를 권장한다:
+
+- 완료된 BL/PR 번호가 기존 `project_*.md`의 기록과 달라지는가?
+- 진행 우선순위가 바뀌었는가 (Next에서 완료/승격)?
+- 이번 세션에서 새로 배운 피드백/제약(사용자 판단 근거, 기각된 대안)이 있는가?
+
+→ "동기화" / "건너뛰기"
+
+"동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
+
 <!-- @state-update: 옵션 A 완료 → Current Phase를 finished로 -->
 **devflow 종료 처리** (devflow-state.md가 존재하는 경우):
 1. `devflow-docs/devflow-state.md`의 `## Current Phase`를 `finished`로 업데이트
@@ -192,6 +204,18 @@ devflow는 PR 머지 후 종료 처리됩니다.
 → "정리" 또는 "건너뛰기"
 ```
 사용자가 "정리"를 선택하면 파일을 열어 함께 정리한다. "건너뛰기"하면 그대로 진행한다.
+
+**Memory Sync Reconciliation** (프로젝트 auto-memory 갱신 필요 여부 확인):
+
+이번 사이클 결과가 auto-memory에 반영돼야 하는지 점검한다. 하나라도 해당되면 "동기화"를 권장한다:
+
+- 완료된 BL/PR 번호가 기존 `project_*.md`의 기록과 달라지는가?
+- 진행 우선순위가 바뀌었는가 (Next에서 완료/승격)?
+- 이번 세션에서 새로 배운 피드백/제약(사용자 판단 근거, 기각된 대안)이 있는가?
+
+→ "동기화" / "건너뛰기"
+
+"동기화" 선택 시: 해당 프로젝트의 auto-memory 디렉토리(`~/.claude/projects/.../memory/`)에서 관련 `project_*.md` 또는 `feedback_*.md`를 업데이트한다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
 <!-- @state-update: 옵션 B PR 생성 → Finishing Choice + PR URL 기록 -->
 **devflow state 유지**: 옵션 B에서는 devflow-state.md를 아카이브하지 않는다. PR 머지 후 다음 세션에서 using-devflow가 PR 머지 확인 → 종료 처리를 안내한다. devflow-state에 `## Finishing Choice`를 `B (PR pending)` + `## PR URL`을 `[github-pr-url]`로 기록한다.

--- a/skills/aidlc-finishing-a-development-branch/SKILL.md
+++ b/skills/aidlc-finishing-a-development-branch/SKILL.md
@@ -144,7 +144,8 @@ git worktree prune
 
 "동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
-> 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
+**실행 기록** (이 프롬프트가 표시되면 `devflow-docs/audit.md`에 한 줄 append):
+`[<ISO timestamp>] memory-sync-reconciliation-prompted | option=<A|B> | choice=<sync|skip>`
 
 <!-- @state-update: 옵션 A 완료 → Current Phase를 finished로 -->
 **devflow 종료 처리** (devflow-state.md가 존재하는 경우):
@@ -219,7 +220,8 @@ devflow는 PR 머지 후 종료 처리됩니다.
 
 "동기화" 선택 시: **현재 repo(cwd)에 매핑되는 프로젝트 auto-memory 디렉토리**(Claude Code 규약상 `~/.claude/projects/<dashed-cwd>/memory/`)의 관련 `project_*.md` 또는 `feedback_*.md`만 업데이트한다. 다른 프로젝트 memory는 건드리지 않는다. auto-memory 시스템이 구성돼 있지 않으면 이 체크는 no-op으로 넘긴다.
 
-> 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 프롬프트가 표시되면 Jay에게 "Memory Sync Reconciliation 프롬프트 출력됨"을 명시적으로 알리고, issue #177에 `observed (3-1)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
+**실행 기록** (이 프롬프트가 표시되면 `devflow-docs/audit.md`에 한 줄 append):
+`[<ISO timestamp>] memory-sync-reconciliation-prompted | option=<A|B> | choice=<sync|skip>`
 
 <!-- @state-update: 옵션 B PR 생성 → Finishing Choice + PR URL 기록 -->
 **devflow state 유지**: 옵션 B에서는 devflow-state.md를 아카이브하지 않는다. PR 머지 후 다음 세션에서 using-devflow가 PR 머지 확인 → 종료 처리를 안내한다. devflow-state에 `## Finishing Choice`를 `B (PR pending)` + `## PR URL`을 `[github-pr-url]`로 기록한다.

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -121,11 +121,12 @@ metadata:
 2. `devflow-docs/session-summary.md` 읽기 (있으면)
 
    **Memory Sync Staleness Check** *(optional, auto-memory 운영 시)*:
-   - (a) 머지 이력 비교 — `MEMORY.md`/`project_*.md` 최근 PR/BL 번호와 `git log --first-parent main -10` 대조
-   - (b) 로컬 미푸시 검사 — `git rev-list --count origin/main..HEAD` ≥ 1이면 unpushed 존재
-   - 임계: (a)에서 3 PR 이상 또는 3일 이상 불일치, 또는 (b)에서 미푸시 발견 시 아래 프롬프트
-   - 프롬프트: "⚠️ Memory staleness / push 보류 감지 — memory PR #N / git latest PR #M (+K) / local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
-   - auto-memory 부재 또는 (a)(b) 모두 0이면 no-op
+   - 로컬 미푸시 검사 — `git rev-list --count @{upstream}..HEAD` (현재 브랜치의 upstream 대비 ahead)
+   - upstream이 미설정이면 이 신호는 스킵 (로컬 전용 브랜치로 간주)
+   - ahead ≥ 1이면 아래 프롬프트:
+     "⚠️ push 보류 감지 — local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
+   - B 선택 시 `devflow-docs/audit.md`에 `memory-sync-staleness-skipped` 이벤트를 한 줄 append (override 사유 추적용)
+   - upstream 미설정 또는 ahead 0이면 no-op
 
    > 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 Step 2.5 실행 시 Jay에게 "Memory Sync Staleness Check 실행됨"을 명시적으로 알리고, issue #177에 `observed (3-2)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
 

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -123,9 +123,11 @@ metadata:
    **Memory Sync Staleness Check** *(optional, auto-memory 운영 시)*:
    - **Preflight — upstream 확인**: `git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null`
      - 성공 → ahead check 진행
-     - 실패 → "upstream 미설정 — staleness check 비활성. 필요 시 `git push -u origin HEAD`로 upstream 설정" 안내 후 이 step 종료
+     - 실패 → "upstream 미설정 — staleness check 비활성. 필요 시 `git push -u origin HEAD`로 upstream 설정" 안내 + `devflow-docs/audit.md`에 한 줄 기록 후 이 step 종료:
+       `[<ISO timestamp>] memory-sync-staleness-skipped | branch=<name> | ahead=0 | reason=upstream-unset`
    - **Ahead check**: `git rev-list --count @{upstream}..HEAD`. 1 이상이면 아래 프롬프트:
      "⚠️ push 보류 감지 — local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
+   - **A 선택 시 권장 절차** (강제 아님, advisory): (1) `git push` 실행 → (2) 성공 시 `git rev-list --count @{upstream}..HEAD` 재확인하여 ahead==0이면 Resume 진행. sync 실패 시 에러 표시 + Resume 보류 권고(최종 판단은 사용자).
    - **실행 기록** (preflight 통과 시 항상) — `devflow-docs/audit.md`에 한 줄 append:
      `[<ISO timestamp>] memory-sync-staleness-check-run | branch=<name> | ahead=<N> | prompted=<true|false>`
    - **B 선택 시 추가 기록**:

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -119,6 +119,14 @@ metadata:
 
 1. `devflow-docs/devflow-state.md` 읽기
 2. `devflow-docs/session-summary.md` 읽기 (있으면)
+
+   **Memory Sync Staleness Check** *(optional, auto-memory 운영 시)*:
+   - (a) 머지 이력 비교 — `MEMORY.md`/`project_*.md` 최근 PR/BL 번호와 `git log --first-parent main -10` 대조
+   - (b) 로컬 미푸시 검사 — `git rev-list --count origin/main..HEAD` ≥ 1이면 unpushed 존재
+   - 임계: (a)에서 3 PR 이상 또는 3일 이상 불일치, 또는 (b)에서 미푸시 발견 시 아래 프롬프트
+   - 프롬프트: "⚠️ Memory staleness / push 보류 감지 — memory PR #N / git latest PR #M (+K) / local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
+   - auto-memory 부재 또는 (a)(b) 모두 0이면 no-op
+
 3. **백로그 확인 (Lazy Loading)**: `devflow-docs/backlog.md`가 존재하면:
    - `## Next`, `## Open` 섹션의 항목 수(`- **BL-` 패턴)만 카운트한다. 파일 내용은 로드하지 않는다.
    - 안내 표시:

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -127,6 +127,8 @@ metadata:
    - 프롬프트: "⚠️ Memory staleness / push 보류 감지 — memory PR #N / git latest PR #M (+K) / local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
    - auto-memory 부재 또는 (a)(b) 모두 0이면 no-op
 
+   > 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 Step 2.5 실행 시 Jay에게 "Memory Sync Staleness Check 실행됨"을 명시적으로 알리고, issue #177에 `observed (3-2)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
+
 3. **백로그 확인 (Lazy Loading)**: `devflow-docs/backlog.md`가 존재하면:
    - `## Next`, `## Open` 섹션의 항목 수(`- **BL-` 패턴)만 카운트한다. 파일 내용은 로드하지 않는다.
    - 안내 표시:

--- a/skills/aidlc-using-devflow/SKILL.md
+++ b/skills/aidlc-using-devflow/SKILL.md
@@ -121,14 +121,16 @@ metadata:
 2. `devflow-docs/session-summary.md` 읽기 (있으면)
 
    **Memory Sync Staleness Check** *(optional, auto-memory 운영 시)*:
-   - 로컬 미푸시 검사 — `git rev-list --count @{upstream}..HEAD` (현재 브랜치의 upstream 대비 ahead)
-   - upstream이 미설정이면 이 신호는 스킵 (로컬 전용 브랜치로 간주)
-   - ahead ≥ 1이면 아래 프롬프트:
+   - **Preflight — upstream 확인**: `git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null`
+     - 성공 → ahead check 진행
+     - 실패 → "upstream 미설정 — staleness check 비활성. 필요 시 `git push -u origin HEAD`로 upstream 설정" 안내 후 이 step 종료
+   - **Ahead check**: `git rev-list --count @{upstream}..HEAD`. 1 이상이면 아래 프롬프트:
      "⚠️ push 보류 감지 — local ahead J commits. A) 갱신 후 Resume / B) 그대로 Resume"
-   - B 선택 시 `devflow-docs/audit.md`에 `memory-sync-staleness-skipped` 이벤트를 한 줄 append (override 사유 추적용)
-   - upstream 미설정 또는 ahead 0이면 no-op
-
-   > 📌 **관측 요청 (BL-092 L3, ~2026-04-28 T+14까지)**: 이 Step 2.5 실행 시 Jay에게 "Memory Sync Staleness Check 실행됨"을 명시적으로 알리고, issue #177에 `observed (3-2)` 코멘트를 제안. T+14 Phase 2 plan 작성 시 이 hint 제거 예정 (만료 test가 강제).
+   - **실행 기록** (preflight 통과 시 항상) — `devflow-docs/audit.md`에 한 줄 append:
+     `[<ISO timestamp>] memory-sync-staleness-check-run | branch=<name> | ahead=<N> | prompted=<true|false>`
+   - **B 선택 시 추가 기록**:
+     `[<ISO timestamp>] memory-sync-staleness-skipped | branch=<name> | ahead=<N> | reason=<optional>`
+   - upstream 미설정 또는 ahead 0이면 프롬프트는 no-op
 
 3. **백로그 확인 (Lazy Loading)**: `devflow-docs/backlog.md`가 존재하면:
    - `## Next`, `## Open` 섹션의 항목 수(`- **BL-` 패턴)만 카운트한다. 파일 내용은 로드하지 않는다.

--- a/tests/test_memory_sync_reconciliation.py
+++ b/tests/test_memory_sync_reconciliation.py
@@ -1,14 +1,13 @@
 """Memory Sync Reconciliation 섹션 구조 검증 (BL-092).
 
 finishing-a-development-branch 옵션 A/B와 using-devflow Resume Flow에
-Memory Sync 관련 섹션이 회귀 없이 유지되는지 정적 검증.
+Memory Sync 관련 섹션이 회귀 없이 유지되고, audit.md 이벤트 로깅 포맷이
+일관되게 유지되는지 정적 검증.
 
-L3 관측 hint는 만료일(2026-04-28) 이후 warning 모드로 전환되며,
-HARD_FAIL_DATE(2026-05-05, +7일 유예) 이후에만 fail하여 제거 강제.
+Codex Round 2 리뷰 반영: L3 hint + 만료 강제 접근은 폐기. 관측은 audit.md
+이벤트 로깅으로 대체. T+14 재평가 사항은 project_bl092_observation.md memory.
 """
-import datetime
 import pathlib
-import warnings
 
 SKILLS_DIR = pathlib.Path(__file__).resolve().parent.parent / "skills"
 
@@ -33,11 +32,7 @@ class TestFinishingMemorySyncReconciliation:
             assert token in self.content, f"Missing prompt token: {token}"
 
     def test_has_checklist_keywords(self):
-        for keyword in [
-            "project_*.md",
-            "feedback_*.md",
-            "Next에서 완료/승격",
-        ]:
+        for keyword in ["project_*.md", "feedback_*.md", "Next에서 완료/승격"]:
             assert keyword in self.content, f"Missing checklist keyword: {keyword}"
 
     def test_has_no_op_clause_for_absent_auto_memory(self):
@@ -46,14 +41,29 @@ class TestFinishingMemorySyncReconciliation:
 
     def test_has_cwd_scoped_memory_path(self):
         """M2: 메모리 대상은 현재 repo(cwd) 디렉토리로만 한정됨을 명시."""
-        assert "현재 repo(cwd)에 매핑되는" in self.content, (
-            "Missing cwd-scoping clause (M2 fix)"
+        assert "현재 repo(cwd)에 매핑되는" in self.content
+        assert "<dashed-cwd>" in self.content
+        assert "다른 프로젝트 memory는 건드리지 않는다" in self.content
+
+    def test_has_reconciliation_prompted_event(self):
+        """M1: audit 이벤트 이름 지정 (고정 포맷)."""
+        assert "memory-sync-reconciliation-prompted" in self.content, (
+            "Missing reconciliation-prompted audit event"
         )
-        assert "<dashed-cwd>" in self.content, (
-            "Missing dashed-cwd path pattern (M2 fix)"
-        )
-        assert "다른 프로젝트 memory는 건드리지 않는다" in self.content, (
-            "Missing cross-project isolation clause (M2 fix)"
+
+    def test_reconciliation_audit_has_option_and_choice_fields(self):
+        """audit 이벤트 포맷 필드 검증: option, choice."""
+        for field in ["option=<A|B>", "choice=<sync|skip>"]:
+            assert field in self.content, f"Missing audit field: {field}"
+
+    def test_audit_writes_to_devflow_docs_audit_md(self):
+        """audit.md append 지시 포함."""
+        assert "devflow-docs/audit.md" in self.content
+
+    def test_l3_hint_removed(self):
+        """Codex Round 2 반영: 임시 L3 hint 블록은 제거됨."""
+        assert "관측 요청 (BL-092 L3" not in self.content, (
+            "L3 observation hint should be removed (superseded by audit logging)"
         )
 
     def test_positioned_before_state_update_markers(self):
@@ -83,32 +93,54 @@ class TestUsingDevflowStalenessCheck:
     def test_has_staleness_check_block(self):
         assert "Memory Sync Staleness Check" in self.content
 
+    def test_has_upstream_preflight(self):
+        """H1: upstream 존재를 ahead check 이전에 확인."""
+        assert "git rev-parse --abbrev-ref --symbolic-full-name @{upstream}" in self.content, (
+            "Missing upstream preflight command"
+        )
+        # Preflight 실패(미설정) 시 step 종료 지시
+        assert "upstream 미설정" in self.content
+        assert "staleness check 비활성" in self.content
+
     def test_uses_upstream_based_ahead_check(self):
-        """H1: upstream 대비 ahead check (origin/main 고정 비교가 아님)."""
-        assert "git rev-list --count @{upstream}..HEAD" in self.content, (
-            "Must use @{upstream}..HEAD (not origin/main..HEAD) for ahead check"
-        )
-        assert "upstream이 미설정이면 이 신호는 스킵" in self.content, (
-            "Missing upstream-absent skip clause"
-        )
+        """H1: ahead check는 @{upstream} 기준 (origin/main 고정 아님)."""
+        assert "git rev-list --count @{upstream}..HEAD" in self.content
 
     def test_merge_history_signal_removed(self):
-        """H2: 불안정한 PR/BL 번호 비교 signal은 제거됨."""
+        """H2: 불안정한 PR/BL 번호 비교 signal은 영구히 제거됨."""
         assert "git log --first-parent main" not in self.content, (
-            "Merge history comparison signal should be removed (H2)"
+            "Merge history comparison signal should stay removed"
         )
 
-    def test_has_audit_log_on_skip(self):
-        """M1: B 선택 시 audit.md에 override 이벤트 기록."""
-        assert "memory-sync-staleness-skipped" in self.content, (
-            "Missing audit log event name for skipped override (M1)"
-        )
+    def test_has_staleness_check_run_event(self):
+        """M1 확장: preflight 통과 시 항상 실행 기록."""
+        assert "memory-sync-staleness-check-run" in self.content
+
+    def test_has_staleness_skipped_event(self):
+        """M1: B 선택 시 skipped 이벤트 기록."""
+        assert "memory-sync-staleness-skipped" in self.content
+
+    def test_audit_events_have_required_fields(self):
+        """포맷 필드 검증: branch, ahead, prompted (check-run) / reason (skipped)."""
+        for field in [
+            "branch=<name>",
+            "ahead=<N>",
+            "prompted=<true|false>",
+            "reason=<optional>",
+        ]:
+            assert field in self.content, f"Missing audit field spec: {field}"
 
     def test_has_no_op_clause(self):
         assert "no-op" in self.content
 
+    def test_l3_hint_removed(self):
+        """Codex Round 2 반영: 임시 L3 hint 블록은 제거됨."""
+        assert "관측 요청 (BL-092 L3" not in self.content, (
+            "L3 observation hint should be removed (superseded by audit logging)"
+        )
+
     def test_positioned_between_step_2_and_step_3(self):
-        """Step 2 (session-summary 읽기) 이후, Step 3 (백로그 확인) 이전에 위치."""
+        """Step 2 이후, Step 3 이전에 위치."""
         resume_flow_start = self.content.index("### Resume Flow")
         step_2 = self.content.index(
             "session-summary.md` 읽기 (있으면)", resume_flow_start
@@ -118,76 +150,3 @@ class TestUsingDevflowStalenessCheck:
         assert step_2 < staleness < step_3, (
             "Staleness Check must be positioned between Step 2 and Step 3"
         )
-
-
-class TestL3ObservationHintExpiry:
-    """BL-092 L3 관측 hint의 lifecycle을 2단계로 관리:
-
-    - 2026-04-28 (EXPIRY_DATE) 이전: hint 존재 보장 (회귀 방지)
-    - 2026-04-28 ~ 2026-05-04: warning 모드 (통과하되 제거 알림)
-    - 2026-05-05 (HARD_FAIL_DATE) 이후: hard fail로 제거 강제
-
-    Codex adversarial review (H3) 권고 반영: 즉시 hard-fail 대신 7일 유예로
-    긴급/핫픽스 작업 중 pipeline block 위험 완화.
-    """
-
-    EXPIRY_DATE = datetime.date(2026, 4, 28)
-    HARD_FAIL_DATE = datetime.date(2026, 5, 5)
-    HINT_MARKER = "관측 요청 (BL-092 L3"
-
-    def setup_method(self):
-        self.finishing = (
-            SKILLS_DIR / "aidlc-finishing-a-development-branch" / "SKILL.md"
-        ).read_text()
-        self.using = (
-            SKILLS_DIR / "aidlc-using-devflow" / "SKILL.md"
-        ).read_text()
-
-    def _hint_present(self):
-        return (
-            self.HINT_MARKER in self.finishing
-            or self.HINT_MARKER in self.using
-        )
-
-    def _removal_guide(self, phase):
-        return (
-            f"\n\n=== BL-092 L3 hint {phase} ===\n"
-            f"다음 파일에서 '{self.HINT_MARKER}' 블록 제거 필요:\n"
-            f"  - skills/aidlc-finishing-a-development-branch/SKILL.md "
-            f"(2곳: 옵션 A/B Memory Sync Reconciliation 섹션 말미)\n"
-            f"  - skills/aidlc-using-devflow/SKILL.md "
-            f"(Step 2.5 Memory Sync Staleness Check 말미)\n"
-            f"제거 후 이 test 클래스(TestL3ObservationHintExpiry)도 함께 삭제."
-        )
-
-    def test_hints_lifecycle(self):
-        today = datetime.date.today()
-
-        if today < self.EXPIRY_DATE:
-            # Phase 1: 만료 전 — hint 존재 보장
-            assert self.HINT_MARKER in self.finishing, (
-                f"L3 hint missing from finishing SKILL.md before expiry "
-                f"{self.EXPIRY_DATE} (today={today})"
-            )
-            assert self.HINT_MARKER in self.using, (
-                f"L3 hint missing from using-devflow SKILL.md before expiry "
-                f"{self.EXPIRY_DATE} (today={today})"
-            )
-            assert self.finishing.count(self.HINT_MARKER) == 2, (
-                "Expected hint in both 옵션 A and 옵션 B of finishing SKILL.md"
-            )
-        elif today < self.HARD_FAIL_DATE:
-            # Phase 2: 만료 ~ +7일 — warning만, test는 통과
-            if self._hint_present():
-                days_over = (today - self.EXPIRY_DATE).days
-                warnings.warn(
-                    f"⚠️ BL-092 L3 hint 만료 경과 {days_over}일. "
-                    f"{self.HARD_FAIL_DATE}부터 test hard-fail. 즉시 제거 권장."
-                    + self._removal_guide(f"만료 경과 (현재 warning, {self.HARD_FAIL_DATE}부터 fail)"),
-                    stacklevel=2,
-                )
-        else:
-            # Phase 3: HARD_FAIL_DATE 이후 — hint 제거 강제
-            guide = self._removal_guide(f"만료 + 유예 초과 ({self.HARD_FAIL_DATE})")
-            assert self.HINT_MARKER not in self.finishing, guide
-            assert self.HINT_MARKER not in self.using, guide

--- a/tests/test_memory_sync_reconciliation.py
+++ b/tests/test_memory_sync_reconciliation.py
@@ -80,6 +80,20 @@ class TestFinishingMemorySyncReconciliation:
                 f"Memory Sync Reconciliation section not found before {marker}"
             )
 
+    def test_has_dashed_cwd_derivation_rule(self):
+        """Round 3 M2 확장: <dashed-cwd> 생성 규칙 명시 (/ → - 치환)."""
+        assert "`/`를 `-`로 치환" in self.content, (
+            "Missing dashed-cwd derivation rule"
+        )
+        assert "-Users-jay-project" in self.content, (
+            "Missing concrete transform example"
+        )
+
+    def test_has_multi_match_fail_safe(self):
+        """Round 3 M2: 경로 후보가 2개 이상 매치되면 업데이트 중단."""
+        assert "후보 디렉토리가 2개 이상 매치되면" in self.content
+        assert "사용자 확인을 요청" in self.content
+
 
 class TestUsingDevflowStalenessCheck:
     """aidlc-using-devflow SKILL.md Resume Flow에 Memory Sync
@@ -150,3 +164,17 @@ class TestUsingDevflowStalenessCheck:
         assert step_2 < staleness < step_3, (
             "Staleness Check must be positioned between Step 2 and Step 3"
         )
+
+    def test_has_upstream_unset_audit_reason(self):
+        """Round 3 M: preflight 실패도 audit 이벤트로 기록 (reason=upstream-unset)."""
+        assert "reason=upstream-unset" in self.content, (
+            "Missing upstream-unset audit reason for preflight failure"
+        )
+
+    def test_has_a_path_recommended_procedure(self):
+        """Round 3 H1 (부분): A 선택 시 권장 절차 명시. 강제 아님(advisory)."""
+        assert "A 선택 시 권장 절차" in self.content
+        assert "advisory" in self.content, "A-path must remain advisory, not hard block"
+        # 구체 명령 + 재검증
+        assert "git push" in self.content
+        assert "재확인" in self.content

--- a/tests/test_memory_sync_reconciliation.py
+++ b/tests/test_memory_sync_reconciliation.py
@@ -2,7 +2,10 @@
 
 finishing-a-development-branch 옵션 A/B와 using-devflow Resume Flow에
 Memory Sync 관련 섹션이 회귀 없이 유지되는지 정적 검증.
+
+추가로 L3 관측 hint의 만료일(2026-04-28) 경과 시 자동 fail하여 제거를 강제.
 """
+import datetime
 import pathlib
 
 SKILLS_DIR = pathlib.Path(__file__).resolve().parent.parent / "skills"
@@ -86,3 +89,52 @@ class TestUsingDevflowStalenessCheck:
         assert step_2 < staleness < step_3, (
             "Staleness Check must be positioned between Step 2 and Step 3"
         )
+
+
+class TestL3ObservationHintExpiry:
+    """BL-092 L3 관측 hint는 2026-04-28 T+14 만료.
+
+    만료일 이후 hint가 남아있으면 이 test가 fail하여 제거를 강제한다.
+    만료 전에는 hint 존재를 보장해 회귀를 방지한다.
+    """
+
+    EXPIRY_DATE = datetime.date(2026, 4, 28)
+    HINT_MARKER = "관측 요청 (BL-092 L3"
+
+    def setup_method(self):
+        self.finishing = (
+            SKILLS_DIR / "aidlc-finishing-a-development-branch" / "SKILL.md"
+        ).read_text()
+        self.using = (
+            SKILLS_DIR / "aidlc-using-devflow" / "SKILL.md"
+        ).read_text()
+
+    def test_hints_lifecycle(self):
+        today = datetime.date.today()
+        if today < self.EXPIRY_DATE:
+            # 만료 전: hint 존재 보장 (실수로 삭제되면 fail)
+            assert self.HINT_MARKER in self.finishing, (
+                f"L3 hint missing from finishing SKILL.md before expiry "
+                f"{self.EXPIRY_DATE} (today={today})"
+            )
+            assert self.HINT_MARKER in self.using, (
+                f"L3 hint missing from using-devflow SKILL.md before expiry "
+                f"{self.EXPIRY_DATE} (today={today})"
+            )
+            # 옵션 A와 B 두 곳에 모두 존재해야 함
+            assert self.finishing.count(self.HINT_MARKER) == 2, (
+                "Expected hint in both 옵션 A and 옵션 B of finishing SKILL.md"
+            )
+        else:
+            # 만료 후: hint 제거돼야 함
+            removal_guide = (
+                f"\n\n=== BL-092 L3 hint 만료 ({self.EXPIRY_DATE}) ===\n"
+                f"다음 파일에서 '{self.HINT_MARKER}' 블록 제거 필요:\n"
+                f"  - skills/aidlc-finishing-a-development-branch/SKILL.md "
+                f"(2곳: 옵션 A/B의 Memory Sync Reconciliation 섹션 말미)\n"
+                f"  - skills/aidlc-using-devflow/SKILL.md "
+                f"(Step 2.5 Memory Sync Staleness Check 말미)\n"
+                f"제거 후 이 test 클래스(TestL3ObservationHintExpiry)도 함께 삭제."
+            )
+            assert self.HINT_MARKER not in self.finishing, removal_guide
+            assert self.HINT_MARKER not in self.using, removal_guide

--- a/tests/test_memory_sync_reconciliation.py
+++ b/tests/test_memory_sync_reconciliation.py
@@ -1,0 +1,88 @@
+"""Memory Sync Reconciliation 섹션 구조 검증 (BL-092).
+
+finishing-a-development-branch 옵션 A/B와 using-devflow Resume Flow에
+Memory Sync 관련 섹션이 회귀 없이 유지되는지 정적 검증.
+"""
+import pathlib
+
+SKILLS_DIR = pathlib.Path(__file__).resolve().parent.parent / "skills"
+
+
+class TestFinishingMemorySyncReconciliation:
+    """aidlc-finishing-a-development-branch SKILL.md 옵션 A/B에
+    Memory Sync Reconciliation 섹션이 올바르게 추가되었는지 검증."""
+
+    def setup_method(self):
+        self.content = (
+            SKILLS_DIR / "aidlc-finishing-a-development-branch" / "SKILL.md"
+        ).read_text()
+
+    def test_appears_twice_for_options_a_and_b(self):
+        count = self.content.count("**Memory Sync Reconciliation**")
+        assert count == 2, (
+            f"Expected 2 occurrences (옵션 A + 옵션 B), got {count}"
+        )
+
+    def test_has_sync_skip_prompt(self):
+        for token in ['"동기화"', '"건너뛰기"']:
+            assert token in self.content, f"Missing prompt token: {token}"
+
+    def test_has_checklist_keywords(self):
+        for keyword in [
+            "project_*.md",
+            "feedback_*.md",
+            "Next에서 완료/승격",
+        ]:
+            assert keyword in self.content, f"Missing checklist keyword: {keyword}"
+
+    def test_has_no_op_clause_for_absent_auto_memory(self):
+        assert "auto-memory 시스템이 구성돼 있지 않으면" in self.content
+        assert "no-op" in self.content
+
+    def test_positioned_before_state_update_markers(self):
+        """Memory Sync Reconciliation 섹션이 각 옵션의 @state-update 주석 앞에 위치."""
+        for marker in (
+            "<!-- @state-update: 옵션 A 완료",
+            "<!-- @state-update: 옵션 B PR 생성",
+        ):
+            marker_pos = self.content.index(marker)
+            section_pos = self.content.rfind(
+                "**Memory Sync Reconciliation**", 0, marker_pos
+            )
+            assert section_pos > 0, (
+                f"Memory Sync Reconciliation section not found before {marker}"
+            )
+
+
+class TestUsingDevflowStalenessCheck:
+    """aidlc-using-devflow SKILL.md Resume Flow에 Memory Sync
+    Staleness Check step이 올바르게 추가되었는지 검증."""
+
+    def setup_method(self):
+        self.content = (
+            SKILLS_DIR / "aidlc-using-devflow" / "SKILL.md"
+        ).read_text()
+
+    def test_has_staleness_check_block(self):
+        assert "Memory Sync Staleness Check" in self.content
+
+    def test_has_merge_history_check_command(self):
+        assert "git log --first-parent main" in self.content
+
+    def test_has_ahead_count_check_command(self):
+        assert "git rev-list --count origin/main..HEAD" in self.content
+
+    def test_has_no_op_clause(self):
+        assert "no-op" in self.content
+
+    def test_positioned_between_step_2_and_step_3(self):
+        """Step 2 (session-summary 읽기) 이후, Step 3 (백로그 확인) 이전에 위치."""
+        resume_flow_start = self.content.index("### Resume Flow")
+        step_2 = self.content.index(
+            "session-summary.md` 읽기 (있으면)", resume_flow_start
+        )
+        staleness = self.content.index("Memory Sync Staleness Check", step_2)
+        step_3 = self.content.index("백로그 확인 (Lazy Loading)", staleness)
+        assert step_2 < staleness < step_3, (
+            "Staleness Check must be positioned between Step 2 and Step 3"
+        )

--- a/tests/test_memory_sync_reconciliation.py
+++ b/tests/test_memory_sync_reconciliation.py
@@ -3,10 +3,12 @@
 finishing-a-development-branch 옵션 A/B와 using-devflow Resume Flow에
 Memory Sync 관련 섹션이 회귀 없이 유지되는지 정적 검증.
 
-추가로 L3 관측 hint의 만료일(2026-04-28) 경과 시 자동 fail하여 제거를 강제.
+L3 관측 hint는 만료일(2026-04-28) 이후 warning 모드로 전환되며,
+HARD_FAIL_DATE(2026-05-05, +7일 유예) 이후에만 fail하여 제거 강제.
 """
 import datetime
 import pathlib
+import warnings
 
 SKILLS_DIR = pathlib.Path(__file__).resolve().parent.parent / "skills"
 
@@ -42,6 +44,18 @@ class TestFinishingMemorySyncReconciliation:
         assert "auto-memory 시스템이 구성돼 있지 않으면" in self.content
         assert "no-op" in self.content
 
+    def test_has_cwd_scoped_memory_path(self):
+        """M2: 메모리 대상은 현재 repo(cwd) 디렉토리로만 한정됨을 명시."""
+        assert "현재 repo(cwd)에 매핑되는" in self.content, (
+            "Missing cwd-scoping clause (M2 fix)"
+        )
+        assert "<dashed-cwd>" in self.content, (
+            "Missing dashed-cwd path pattern (M2 fix)"
+        )
+        assert "다른 프로젝트 memory는 건드리지 않는다" in self.content, (
+            "Missing cross-project isolation clause (M2 fix)"
+        )
+
     def test_positioned_before_state_update_markers(self):
         """Memory Sync Reconciliation 섹션이 각 옵션의 @state-update 주석 앞에 위치."""
         for marker in (
@@ -69,11 +83,26 @@ class TestUsingDevflowStalenessCheck:
     def test_has_staleness_check_block(self):
         assert "Memory Sync Staleness Check" in self.content
 
-    def test_has_merge_history_check_command(self):
-        assert "git log --first-parent main" in self.content
+    def test_uses_upstream_based_ahead_check(self):
+        """H1: upstream 대비 ahead check (origin/main 고정 비교가 아님)."""
+        assert "git rev-list --count @{upstream}..HEAD" in self.content, (
+            "Must use @{upstream}..HEAD (not origin/main..HEAD) for ahead check"
+        )
+        assert "upstream이 미설정이면 이 신호는 스킵" in self.content, (
+            "Missing upstream-absent skip clause"
+        )
 
-    def test_has_ahead_count_check_command(self):
-        assert "git rev-list --count origin/main..HEAD" in self.content
+    def test_merge_history_signal_removed(self):
+        """H2: 불안정한 PR/BL 번호 비교 signal은 제거됨."""
+        assert "git log --first-parent main" not in self.content, (
+            "Merge history comparison signal should be removed (H2)"
+        )
+
+    def test_has_audit_log_on_skip(self):
+        """M1: B 선택 시 audit.md에 override 이벤트 기록."""
+        assert "memory-sync-staleness-skipped" in self.content, (
+            "Missing audit log event name for skipped override (M1)"
+        )
 
     def test_has_no_op_clause(self):
         assert "no-op" in self.content
@@ -92,13 +121,18 @@ class TestUsingDevflowStalenessCheck:
 
 
 class TestL3ObservationHintExpiry:
-    """BL-092 L3 관측 hint는 2026-04-28 T+14 만료.
+    """BL-092 L3 관측 hint의 lifecycle을 2단계로 관리:
 
-    만료일 이후 hint가 남아있으면 이 test가 fail하여 제거를 강제한다.
-    만료 전에는 hint 존재를 보장해 회귀를 방지한다.
+    - 2026-04-28 (EXPIRY_DATE) 이전: hint 존재 보장 (회귀 방지)
+    - 2026-04-28 ~ 2026-05-04: warning 모드 (통과하되 제거 알림)
+    - 2026-05-05 (HARD_FAIL_DATE) 이후: hard fail로 제거 강제
+
+    Codex adversarial review (H3) 권고 반영: 즉시 hard-fail 대신 7일 유예로
+    긴급/핫픽스 작업 중 pipeline block 위험 완화.
     """
 
     EXPIRY_DATE = datetime.date(2026, 4, 28)
+    HARD_FAIL_DATE = datetime.date(2026, 5, 5)
     HINT_MARKER = "관측 요청 (BL-092 L3"
 
     def setup_method(self):
@@ -109,10 +143,28 @@ class TestL3ObservationHintExpiry:
             SKILLS_DIR / "aidlc-using-devflow" / "SKILL.md"
         ).read_text()
 
+    def _hint_present(self):
+        return (
+            self.HINT_MARKER in self.finishing
+            or self.HINT_MARKER in self.using
+        )
+
+    def _removal_guide(self, phase):
+        return (
+            f"\n\n=== BL-092 L3 hint {phase} ===\n"
+            f"다음 파일에서 '{self.HINT_MARKER}' 블록 제거 필요:\n"
+            f"  - skills/aidlc-finishing-a-development-branch/SKILL.md "
+            f"(2곳: 옵션 A/B Memory Sync Reconciliation 섹션 말미)\n"
+            f"  - skills/aidlc-using-devflow/SKILL.md "
+            f"(Step 2.5 Memory Sync Staleness Check 말미)\n"
+            f"제거 후 이 test 클래스(TestL3ObservationHintExpiry)도 함께 삭제."
+        )
+
     def test_hints_lifecycle(self):
         today = datetime.date.today()
+
         if today < self.EXPIRY_DATE:
-            # 만료 전: hint 존재 보장 (실수로 삭제되면 fail)
+            # Phase 1: 만료 전 — hint 존재 보장
             assert self.HINT_MARKER in self.finishing, (
                 f"L3 hint missing from finishing SKILL.md before expiry "
                 f"{self.EXPIRY_DATE} (today={today})"
@@ -121,20 +173,21 @@ class TestL3ObservationHintExpiry:
                 f"L3 hint missing from using-devflow SKILL.md before expiry "
                 f"{self.EXPIRY_DATE} (today={today})"
             )
-            # 옵션 A와 B 두 곳에 모두 존재해야 함
             assert self.finishing.count(self.HINT_MARKER) == 2, (
                 "Expected hint in both 옵션 A and 옵션 B of finishing SKILL.md"
             )
+        elif today < self.HARD_FAIL_DATE:
+            # Phase 2: 만료 ~ +7일 — warning만, test는 통과
+            if self._hint_present():
+                days_over = (today - self.EXPIRY_DATE).days
+                warnings.warn(
+                    f"⚠️ BL-092 L3 hint 만료 경과 {days_over}일. "
+                    f"{self.HARD_FAIL_DATE}부터 test hard-fail. 즉시 제거 권장."
+                    + self._removal_guide(f"만료 경과 (현재 warning, {self.HARD_FAIL_DATE}부터 fail)"),
+                    stacklevel=2,
+                )
         else:
-            # 만료 후: hint 제거돼야 함
-            removal_guide = (
-                f"\n\n=== BL-092 L3 hint 만료 ({self.EXPIRY_DATE}) ===\n"
-                f"다음 파일에서 '{self.HINT_MARKER}' 블록 제거 필요:\n"
-                f"  - skills/aidlc-finishing-a-development-branch/SKILL.md "
-                f"(2곳: 옵션 A/B의 Memory Sync Reconciliation 섹션 말미)\n"
-                f"  - skills/aidlc-using-devflow/SKILL.md "
-                f"(Step 2.5 Memory Sync Staleness Check 말미)\n"
-                f"제거 후 이 test 클래스(TestL3ObservationHintExpiry)도 함께 삭제."
-            )
-            assert self.HINT_MARKER not in self.finishing, removal_guide
-            assert self.HINT_MARKER not in self.using, removal_guide
+            # Phase 3: HARD_FAIL_DATE 이후 — hint 제거 강제
+            guide = self._removal_guide(f"만료 + 유예 초과 ({self.HARD_FAIL_DATE})")
+            assert self.HINT_MARKER not in self.finishing, guide
+            assert self.HINT_MARKER not in self.using, guide


### PR DESCRIPTION
Closes #177
refs #176 (BL-091 자매)

## Summary

세션 경계에서 auto-memory stale / push 보류를 감지하는 **advisory** 체크포인트 MVP.

- **finishing-a-development-branch** 옵션 A/B: **Memory Sync Reconciliation** 섹션 — auto-memory 갱신 체크리스트 + "동기화/건너뛰기" 프롬프트 + audit.md 이벤트 기록
- **using-devflow** Resume Flow Step 2.5: **Memory Sync Staleness Check** — upstream preflight + ahead check + audit.md 3종 이벤트
- **plugin 1.10.0 → 1.10.1**

**advisory only** (hard block 없음). 관측은 audit.md 이벤트 로깅 기반.

## Audit 이벤트 포맷 (3종)

- `memory-sync-reconciliation-prompted | option=<A|B> | choice=<sync|skip>` — finishing 옵션 A/B 프롬프트 표시 시
- `memory-sync-staleness-check-run | branch=<name> | ahead=<N> | prompted=<true|false>` — using-devflow Step 2.5 실행 시
- `memory-sync-staleness-skipped | branch=<name> | ahead=<N> | reason=<optional>` — 사용자 B 선택 또는 `reason=upstream-unset`

## 실증 사례

- **nexttui (2026-04-18)**: `project_*.md` 2-3일 stale → 새 세션이 구식 baseline으로 시작할 뻔함.
- **aidlc-devflow (2026-04-17~20)**: 커밋 `7d96e6a`가 main 직접 커밋 + push 보류로 3일 unpushed. MVP ahead check가 감지하는 케이스.

## Codex Adversarial Review 대응 (3 rounds)

| Round | Verdict → 대응 |
|---|---|
| **1** | No-ship → H1 `@{upstream}..HEAD` 전환 / H2 PR/BL 비교 signal 제거 / H3 만료 test 2단계 lifecycle / M1 audit 이벤트 추가 / M2 cwd scoping 명시 |
| **2** | No-ship → **L3 hint 접근 전체 폐기 + audit.md event logging으로 대체** / preflight 추가 / 3종 이벤트 포맷 고정 |
| **3** | needs-attention → A 경로 권장 절차 명시(advisory 유지) / preflight 실패 audit 기록 / `<dashed-cwd>` 파생 규칙 명시 |

### T+14 재평가 연기 항목 (3중 추적)

- `project_bl092_observation.md` auto-memory
- Issue #176 (BL-091) cross-ref 코멘트
- Issue #177 (BL-092) closing note

1. **M1 강제 sync 전환** — audit 로그 빈도 데이터 기반 판단
2. **M3 SPEC boundary ADR** — `docs/research/checkpoint-memorize/SPEC_devflow_checkpoint.md`와 책임 경계 문서화
3. **BL-091 통합 설계** — End-of-Flow Sync 단일 설계 병합 여부

## Test plan

- [x] `bash tests/run-all.sh` — 297 passed (기존 273 + MVP 24)
- [x] 메타 태그(`@state-update` 등) 영향도 — 변경 없음
- [x] L1 구조적 pytest — `tests/test_memory_sync_reconciliation.py` 24 tests
- [x] Codex Round 1/2/3 adversarial review — 연기 항목 외 finding 전부 반영
- [x] L3 hint 제거 회귀 검증 — `test_l3_hint_removed` (finishing/using 둘 다)
- [ ] L3 자연 관측 (3-1): 머지 시 finishing A/B에서 프롬프트 + audit 이벤트 기록 확인 (관측: `grep "memory-sync-reconciliation-prompted" devflow-docs/audit.md`)
- [ ] L3 자연 관측 (3-2): 다음 aidlc-devflow Resume에서 Step 2.5 + audit 이벤트 기록 확인 (관측: `grep "memory-sync-staleness-" devflow-docs/audit.md`)
- [~] L3 (3-3) auto-memory 부재 no-op — 건너뛰기 (L1에서 문구 존재 검증 완료)
- [ ] L2 행동 검증(subagent eval) — BL-042 스코프, 별도

## Non-goals

- 하드 블록 / 훅 (advisory only)
- Taxonomy 수정 (6-type 유지)
- 새 파일 구조 (기존 `session-summary.md` + `audit.md` 재활용)
- 자동 memory 수정 (사용자 확인 프롬프트만)
- 강제 sync / 재검증 gate — **T+14 재평가 대상**

## SPEC과 범주 분리

`docs/research/checkpoint-memorize/SPEC_devflow_checkpoint.md`는 **PR 리뷰어용 context amplifier** 설계 (write-path, per-push). 이번 MVP는 **세션 연속성 (자기 자신의 다음 세션)** 대상 (read-path, advisory). 대상·수혜자·저장소가 달라 병행 가능. 용어 충돌 회피를 위해 MVP는 "Reconciliation"/"Staleness Check" 어휘 사용. 장기 경계 ADR은 T+14 연기 항목.

## 후속 정리 (머지 후)

- backlog.md `## Next`에서 BL-092 제거 (Done 상태로 전환)
- `v1.10.1` git tag push → sync-marketplace workflow 자동 실행