### PR TITLE
chore(docs): remove BL-092 from backlog Next

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -12,7 +12,6 @@
 - **BL-086**: aidlc-writing-plans에 mapping/매핑 검증 단계 추가 — Task 4 사고 재발 방지 [P2] [#155](https://github.com/bluejayA/aidlc-devflow/issues/155)
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
-- **BL-092**: Memory Sync Reconciliation MVP — finishing 스킬 + using-devflow staleness check (BL-091 자매, refs #176) [P2] [#177](https://github.com/bluejayA/aidlc-devflow/issues/177)
 
 > BL-085 (Knowledge System Phase 1)는 구현 완료 후 본 파일에서 제거 (git history로 추적).
 > Baseline + Phase 2 trigger 평가 기준: `docs/research/knowledgesystem/phase1-baseline.md` 참조.


### PR DESCRIPTION
## Summary

BL-092 (PR #178) 머지 완료에 따라 \`devflow-docs/backlog.md\` Next 섹션에서 해당 항목 제거.

backlog 관리 규칙: 완료된 항목은 파일에서 제거하고 git history로 추적.

## Test plan

- [x] 단일 라인 삭제, 다른 항목 무변경
- [x] \`bash tests/run-all.sh\` 297 passed 유지 확인 필요 없음 (backlog.md는 test 영향 없음)

refs #177