### PR TITLE
chore(docs): remove stale BL-085 removal notice from backlog

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -13,8 +13,7 @@
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
 
-> BL-085 (Knowledge System Phase 1)는 구현 완료 후 본 파일에서 제거 (git history로 추적).
-> Baseline + Phase 2 trigger 평가 기준: `docs/research/knowledgesystem/phase1-baseline.md` 참조.
+> Phase 2 Knowledge System 관측 진행 중. Baseline + trigger 평가 기준: `docs/research/knowledgesystem/phase1-baseline.md` 참조.
 
 ---
 


### PR DESCRIPTION
## Summary

BL-085 (Knowledge System Phase 1, #154)가 PR #157로 이미 머지·제거 완료됨(2026-04-13). backlog.md의 "제거 예정" 안내 주석은 의미를 다해 삭제. Phase 2 관측 참조 주석만 간결하게 유지.

## Test plan

- [x] 1줄 삭제 + 1줄 축약. 다른 항목/구조 무변경
- [x] 실제 BL 항목/GitHub 이슈 매핑은 이미 현행화 상태였음 (대조 완료)