### PR TITLE
feat(skills): Traps to Avoid 섹션 + orchestrator 회수 절차 (BL-094)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -12,7 +12,6 @@
 - **BL-086**: aidlc-writing-plans에 mapping/매핑 검증 단계 추가 — Task 4 사고 재발 방지 [P2] [#155](https://github.com/bluejayA/aidlc-devflow/issues/155)
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
-- **BL-093**: Handoff Strategy: session-summary.md 작성 규칙 6항 명시 (작성 규칙 텍스트만, 강제는 094/095) [P2] [#181](https://github.com/bluejayA/aidlc-devflow/issues/181)
 - **BL-094**: Handoff Strategy: "Traps to Avoid" 섹션 + 운영 규칙 (orchestrator 회수, hook 강제는 BL-090 흡수) [P2] [#182](https://github.com/bluejayA/aidlc-devflow/issues/182)
 - **BL-095**: Handoff Strategy: "Handoff = hypothesis" 원칙 명문화 — Phase 1만 (Phase 2는 BL-095b) [P2] [#183](https://github.com/bluejayA/aidlc-devflow/issues/183)
 - **BL-095b**: Handoff Strategy: session-summary verification gate (Phase 2, evidence=산출물 디렉터리+git log) [P2] [#184](https://github.com/bluejayA/aidlc-devflow/issues/184)

--- a/skills/_shared/patterns/session-continuity.md
+++ b/skills/_shared/patterns/session-continuity.md
@@ -151,6 +151,11 @@ INCEPTION 중간에 세션이 끊겨도 재개 시 이 파일로 맥락 복원 �
 - [다음 작업 설명]
 <!-- Key Decisions, Completed Work는 최근 20개까지만 유지. 초과 시 오래된 항목 삭제. -->
 
+## Traps to Avoid
+- [폐기한 접근 1]: [이유]로 폐기. 재시도 금지.
+- [폐기한 접근 2]: ...
+<!-- 비어 있으면 (없음) 한 줄만 둔다. 섹션 자체를 삭제하지 않는다. -->
+
 ## For Next Session
 - [인수인계 시 알아야 할 핵심 맥락]
 - [주의사항이나 미해결 이슈]
@@ -213,6 +218,34 @@ session-summary.md는 registry 수준 (~2,000 토큰 이내, 약 80~100줄)만 �
 | 설계 다이어그램, 산출물 | `devflow-docs/inception/`, `devflow-docs/construction/...` |
 
 상한 초과 시 시간이 갈수록 비대화되어 매 세션 로딩 비용이 누적된다. **Commit Hash 기록**(아래)도 최신 1개만 유지하는 이유와 같다.
+
+### Traps to Avoid 운영 규칙
+
+작성 규칙 #3의 운영 측면. 섹션만 추가하고 채우는 규칙이 없으면 빈 `(없음)`만 누적되어 가치가 0이 된다.
+
+#### 회수 시점 및 주체
+
+| 시점 | 주체 | 동작 |
+|------|------|------|
+| INCEPTION stage 게이트 승인 시 | aidlc-inception-orchestrator | "이번 stage에서 폐기한 접근이 있나요? (없으면 enter)" 질문, 응답을 1줄씩 추가 |
+| CONSTRUCTION unit 완료 시 | aidlc-construction-orchestrator | "이번 unit에서 폐기한 시도가 있나요? (없으면 enter)" 질문, 응답을 1줄씩 추가 |
+| 사용자가 명시적으로 "이 접근 폐기" 발화 시 | 응대 중인 스킬/orchestrator | 즉시 회수 (다음 stage-end까지 기다리지 않음) |
+
+#### 회수 형식
+
+회수 답변은 다음 형식으로 정규화한다:
+
+- 좋은 예: `- JWT를 cookie로 옮기는 접근: SameSite 호환성 문제로 폐기. 재시도 금지.`
+- 나쁜 예: `- 인증 잘 안 됨` (이유와 폐기 결론 누락)
+
+#### 빈 응답 처리
+
+사용자가 "없음"이라 답하면 섹션은 유지하고 `(없음)` 한 줄만 둔다. 섹션 자체를 삭제하지 않는다. 다음 stage에서 다시 회수 질문이 나갈 때 누적 가능하도록.
+
+#### 시스템 보완 (out of scope)
+
+- conversational gate라 hook으로 reactive 강제는 어렵다. 본 운영 규칙은 orchestrator 책임으로 둔다.
+- SessionEnd hook 또는 pre-commit hook으로 "Traps 섹션이 비어있는데 폐기한 시도 정말 없었나" 검증은 [BL-090 정합성 linter](https://github.com/bluejayA/aidlc-devflow/issues/175)에 흡수.
 
 ### Commit Hash 기록
 

--- a/skills/aidlc-construction-orchestrator/SKILL.md
+++ b/skills/aidlc-construction-orchestrator/SKILL.md
@@ -222,6 +222,7 @@ requesting-code-review가 모든 리뷰 로직을 소유한다 (Single Source of
 승인 후:
 - devflow-state의 `## Completed Units`에 unit명 추가
 - `devflow-docs/session-summary.md` 업데이트: Completed Work에 unit 추가 + `**Commit**` 필드에 현재 HEAD hash
+- **Traps 회수**: 사용자에게 "이번 unit에서 폐기한 시도가 있나요? (없으면 enter)" 질문. 응답이 있으면 session-summary.md의 `## Traps to Avoid` 섹션에 1줄씩 추가. 응답이 없으면 섹션을 `(없음)`으로 유지. 자세한 운영 규칙은 `_shared/patterns/session-continuity.md`의 "Traps to Avoid 운영 규칙" 참조.
 - devflow-audit에 로깅: `[timestamp] unit-complete: [unit-name] — [commit hash]`
 
 #### 2d. 다음 unit 확인

--- a/skills/aidlc-inception-orchestrator/SKILL.md
+++ b/skills/aidlc-inception-orchestrator/SKILL.md
@@ -60,6 +60,7 @@ devflow-state의 `## Current Stage`를 업데이트하고 해당 스킬을 호�
 - `## Current State`의 Stage 필드 업데이트
 - `## Key Decisions`에 게이트 선택 기록 (결정 이유 포함)
 - `**Commit**` 필드에 현재 HEAD hash
+- **Traps 회수**: 사용자에게 "이번 stage에서 폐기한 접근이 있나요? (없으면 enter)" 질문. 응답이 있으면 `## Traps to Avoid` 섹션에 1줄씩 추가 (형식: `- [접근 요약]: [이유]로 폐기. 재시도 금지.`). 응답이 없으면 섹션을 `(없음)`으로 유지. 자세한 운영 규칙은 `_shared/patterns/session-continuity.md`의 "Traps to Avoid 운영 규칙" 참조.
 
 ### Step C: 게이트 제시
 


### PR DESCRIPTION
Closes #182

## Summary

BL-093([#181](https://github.com/bluejayA/aidlc-devflow/issues/181)) 작성 규칙 #3의 후속 작업. session-summary.md에 폐기한 접근을 회수하는 메커니즘을 정의.

**변경**:
- `session-continuity.md` 표준 템플릿에 `## Traps to Avoid` 섹션 추가 (`## Next Steps`와 `## For Next Session` 사이)
- "Traps to Avoid 운영 규칙" sub-section 신설: 회수 시점/주체/형식/빈 응답 처리 정의
- `aidlc-inception-orchestrator`: stage 게이트 승인 시(`Step B-1`) Traps 회수 질문 추가
- `aidlc-construction-orchestrator`: unit 완료 시 Traps 회수 질문 추가
- `backlog.md`: BL-093 항목 제거 (PR #186 머지로 완료)

**hook 강제는 본 PR에 포함하지 않음**: SessionEnd hook으로 "Traps 비어있음 경고"는 conversational gate를 reactive 강제하기 어려우므로 [BL-090 정합성 linter](https://github.com/bluejayA/aidlc-devflow/issues/175)에 항목으로 흡수 (이미 #175에 코멘트 추가됨).

시나리오 A(순차 PR 3건)의 2/3. 다음: BL-095 Phase 1.

## 영향도 분석

- **session-continuity.md**: 275 → 308 lines (+33). orchestrator 재개 시 +1회 ~700→780 토큰 (~$0.0023/세션)
- **orchestrator SKILL.md 2개**: 각 +1 line. 토큰 영향 무시 수준
- **세션 UX 변화**: stage/unit 종료 시 "폐기한 접근?" 질문 1개 추가 → 사용자 응답 1줄 (없으면 enter)

## Test plan

- [x] `bash tests/run-all.sh` — 297 tests passed
- [x] BL-093 작성 규칙 #3과 본 운영 규칙의 상호 참조 확인 (양방향 링크)
- [ ] PR 머지 후 실제 INCEPTION/CONSTRUCTION 세션에서 Traps 회수 질문이 적절한 시점에 나오는지 관측

🤖 Generated with [Claude Code](https://claude.com/claude-code)