### PR TITLE
feat(skills): Handoff = Hypothesis 원칙 명문화 (BL-095 Phase 1)

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -12,7 +12,6 @@
 - **BL-086**: aidlc-writing-plans에 mapping/매핑 검증 단계 추가 — Task 4 사고 재발 방지 [P2] [#155](https://github.com/bluejayA/aidlc-devflow/issues/155)
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
-- **BL-094**: Handoff Strategy: "Traps to Avoid" 섹션 + 운영 규칙 (orchestrator 회수, hook 강제는 BL-090 흡수) [P2] [#182](https://github.com/bluejayA/aidlc-devflow/issues/182)
 - **BL-095**: Handoff Strategy: "Handoff = hypothesis" 원칙 명문화 — Phase 1만 (Phase 2는 BL-095b) [P2] [#183](https://github.com/bluejayA/aidlc-devflow/issues/183)
 - **BL-095b**: Handoff Strategy: session-summary verification gate (Phase 2, evidence=산출물 디렉터리+git log) [P2] [#184](https://github.com/bluejayA/aidlc-devflow/issues/184)
 

--- a/skills/_shared/patterns/session-continuity.md
+++ b/skills/_shared/patterns/session-continuity.md
@@ -247,6 +247,28 @@ session-summary.md는 registry 수준 (~2,000 토큰 이내, 약 80~100줄)만 �
 - conversational gate라 hook으로 reactive 강제는 어렵다. 본 운영 규칙은 orchestrator 책임으로 둔다.
 - SessionEnd hook 또는 pre-commit hook으로 "Traps 섹션이 비어있는데 폐기한 시도 정말 없었나" 검증은 [BL-090 정합성 linter](https://github.com/bluejayA/aidlc-devflow/issues/175)에 흡수.
 
+### 운영 원칙: Handoff = Hypothesis
+
+session-summary.md는 **fact가 아니라 hypothesis로 다뤄야 한다**. 이전 세션이 혼동 상태에서 작성했다면 새 세션이 그 오류를 그대로 이어받기 때문이다.
+
+#### 핵심 원칙
+
+- session-summary.md의 모든 claim(예: "Unit X 완료", "테스트 통과", "리뷰 반영됨")은 코드/git 상태와 대조해 검증해야 한다.
+- 검증 실패 시 session-summary.md를 우선 갱신한 후 작업을 재개한다. 의심스러운 claim 위에서 작업을 쌓지 않는다.
+- 작성 규칙 #4(검증 지시 포함)는 본 원칙의 작성자 측 표현이고, 시스템 강제는 [BL-095b](https://github.com/bluejayA/aidlc-devflow/issues/184)에서 다룬다.
+
+#### 사용자 가이드 (Phase 1)
+
+새 세션이 session-summary.md를 로드한 직후 다음을 실행한다:
+
+1. **Completed Work 검증**: `## Completed Work`의 각 `[x]` 항목에 대해 산출물 디렉터리(예: `devflow-docs/inception/`, `devflow-docs/construction/{unit}/`) 또는 `git log` 존재 여부를 확인한다. 불일치 시 사용자에게 보고하고 summary를 갱신한다.
+2. **Open Work 재해석**: 명령형 표현("X를 구현하라")이 발견되면 상태 서술형("X는 미구현")으로 재해석한 후 진행 여부를 사용자에게 묻는다 (작성 규칙 #1 위반에 대한 방어선).
+3. **Traps 존중**: `## Traps to Avoid`의 항목을 다시 시도하지 않는다. 상황이 바뀌어 재시도가 필요하면 사용자 명시적 승인을 받는다.
+
+#### 시스템 강제 (Phase 2, out of scope)
+
+orchestrator 재개 step에 verification gate를 삽입하는 시스템 강제는 [BL-095b](https://github.com/bluejayA/aidlc-devflow/issues/184)에서 다룬다. 본 원칙(Phase 1)은 사용자/스킬 측의 운영 가이드만 정의한다. evidence 소스는 산출물 디렉터리 + `git log` 조합 (audit.md는 자기 보고이므로 보조).
+
 ### Commit Hash 기록
 
 기록 지점: 세션 시작/재개, Phase 전환, Unit 구현 완료.


### PR DESCRIPTION
Closes #183

## Summary

Handoff Strategy 시리즈 시나리오 A(순차 PR 3건)의 마지막 PR(3/3). session-summary.md를 다루는 핵심 마인드셋을 명문화.

**변경**: `skills/_shared/patterns/session-continuity.md`에 "운영 원칙: Handoff = Hypothesis" sub-section 추가.

- **핵심 원칙**: session-summary.md는 fact가 아니라 hypothesis. 이전 세션이 혼동 상태에서 작성했다면 새 세션이 그 오류를 그대로 이어받는다.
- **사용자 가이드 (Phase 1)**:
  1. Completed Work 검증 — 산출물 디렉터리 + git log 교차 확인
  2. Open Work 재해석 — 명령형은 상태 서술형으로 재해석 후 사용자 확인
  3. Traps 존중 — 명시적 승인 없이 재시도 금지
- **시스템 강제 (Phase 2)는 분리**: orchestrator 재개 step에 verification gate 삽입은 [BL-095b (#184)](https://github.com/bluejayA/aidlc-devflow/issues/184). evidence 소스는 산출물 디렉터리 + git log 조합 (audit.md는 보조).

`backlog.md`에서 BL-094 항목 제거 (PR #187 머지 cleanup).

## 영향도 분석

- **session-continuity.md**: 308 → 330 lines (+22). orchestrator 재개 시 +1회 ~50 토큰 추가 (~$0.0002/세션, 무시 수준)
- **다른 스킬/orchestrator 변경 없음**: Phase 1은 원칙 텍스트만. 시스템 강제는 Phase 2(BL-095b) 범위
- **상호 참조 명확화**: 작성 규칙 #4("검증 지시 포함") ↔ 본 운영 원칙 ↔ BL-095b(시스템 강제) 3단 연결

## Test plan

- [x] `bash tests/run-all.sh` — 297 tests passed
- [x] BL-093 작성 규칙 #4와 본 원칙의 양방향 참조 확인
- [x] BL-095b 분리 명시 (Phase 1/2 경계 분명)
- [ ] PR 머지 후 4주 관측 (5/22 BL-096 routine이 자동 평가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)