### PR TITLE
chore(backlog): BL-097 등록 — aidlc-pausing-a-session 스킬

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -14,6 +14,7 @@
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)
 - **BL-095**: Handoff Strategy: "Handoff = hypothesis" 원칙 명문화 — Phase 1만 (Phase 2는 BL-095b) [P2] [#183](https://github.com/bluejayA/aidlc-devflow/issues/183)
 - **BL-095b**: Handoff Strategy: session-summary verification gate (Phase 2, evidence=산출물 디렉터리+git log) [P2] [#184](https://github.com/bluejayA/aidlc-devflow/issues/184)
+- **BL-097**: `aidlc-pausing-a-session` 스킬 — mid-cycle stop checklist + 3-way sync (`devflow-state.md` / project auto-memory / git log) — `aidlc-finishing-a-development-branch`의 mid-cycle 형제. 5단계 체크리스트 (state 갱신 / memory 정밀 / 인덱스 / audit commit / 3-way verify) + drift 시 commit 거부. `aidlc-using-devflow` Resume Flow에 자동 drift detect 추가. seed=nexttui BL-P2-085 stale recovery (2026-04-28). 별도 BL 후보: `devflow-state.md` gitignore 정책 재검토 [P2] [#189](https://github.com/bluejayA/aidlc-devflow/issues/189)
 
 > Phase 2 Knowledge System 관측 진행 중. Baseline + trigger 평가 기준: `docs/research/knowledgesystem/phase1-baseline.md` 참조.
 


### PR DESCRIPTION
## Summary (한국어)

mid-cycle 일시정지(pause) 시 `devflow-state.md` / project auto-memory / git log 간 drift를 방지하는 신규 스킬 BL을 backlog에 등록합니다.

- 신규 스킬 **`aidlc-pausing-a-session`** — `aidlc-finishing-a-development-branch`의 mid-cycle 형제
- 5단계 체크리스트 + 3-way cross-check (drift 시 commit 거부)
- `aidlc-using-devflow` Resume Flow에 자동 drift detect 추가
- (별도 BL 후보) `devflow-state.md` gitignore 정책 재검토

**Seed**: nexttui BL-P2-085 (paused 2026-04-27 → resumed 2026-04-28) 시 `devflow-state.md`가 stale (Phase 1만 완료로 기록)인 반면 auto-memory + `code-plan.md`는 정확 → resume cross-check로 발견 + 수동 reconcile 필요.

**근본 원인**: `devflow-state.md`가 `.gitignore` 처리됨 (nexttui PR #81). commit-driven SOT가 아니므로 동기화 책임이 사람에게.

GitHub Issue: #189

## Summary (English)

Register a new BL for a mid-cycle pause skill that prevents drift between `devflow-state.md`, project auto-memory, and git log.

- New skill **`aidlc-pausing-a-session`** — sibling of `aidlc-finishing-a-development-branch` for mid-cycle pauses
- 5-step checklist + 3-way cross-check (block commit on drift)
- Auto drift detection in `aidlc-using-devflow` Resume Flow
- (Separate BL candidate) Revisit `devflow-state.md` gitignore policy

**Seed**: nexttui BL-P2-085 (paused 2026-04-27, resumed 2026-04-28) had stale `devflow-state.md` (only Phase 1 recorded as done) while auto-memory + `code-plan.md` were correct (Phase 1~5 done) → discovered via manual cross-check at resume.

**Root cause**: `devflow-state.md` is `.gitignore`d (nexttui PR #81), so it is not a commit-driven SOT — sync responsibility falls on humans.

Closes nothing (registers a new BL for future implementation).
Refs #189

## Test plan
- [x] Backlog 라인이 `## Next` 섹션에 추가되었는지 확인
- [x] BL 번호 BL-097 (가장 최근 BL-096 다음) 일관성 확인
- [x] GitHub Issue #189과 backlog 라인이 양방향 참조되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)