### PR TITLE
fix(auto-mode): session-summary 6항 + 신규 템플릿 필드 자동 기록

### DIFF
--- a/skills/aidlc-auto-mode/SKILL.md
+++ b/skills/aidlc-auto-mode/SKILL.md
@@ -376,13 +376,30 @@ C → devflow-state `finished` → 세션 종료.
 
 **1단계 — 기록:** 다음 4개 파일을 순서대로 업데이트:
 1. `devflow-state.md` — Current Stage 갱신 (in-progress 제거), `## Last Updated`를 ISO 8601 timestamp로 갱신
-2. `session-summary.md` — Completed Work에 추가 (`_shared/patterns/session-continuity.md` 템플릿 준수)
+2. `session-summary.md` — 아래 §session-summary 갱신 규칙 준수
 3. `devflow-docs/audit.md` — 아래 §audit emit 형식으로 한 줄 append
 4. `auto-decision-log-[phase].md` — 판단 상세 append
 
 **2단계 — 검증:** `devflow-state.md`를 Read로 열어 Current Stage 값 확인. 불일치 시 즉시 수정.
 
 **3단계 — 진행 메시지:** 사용자에게 다음 스테이지 진행 메시지 표시.
+
+### session-summary 갱신 규칙
+
+baseline은 `_shared/patterns/session-continuity.md` (템플릿 + 6항 작성 규칙 + Traps to Avoid 운영 규칙). auto-mode 특수 규칙만 아래 인라인.
+
+**필수 필드 자동 기록**: `Last Updated` (ISO 8601), `Commit` (`git rev-parse --short HEAD`, Phase 전환·Unit 완료 시 갱신), `Completed Work` (`[x]` + 한 줄 결과), `Key Decisions` (최근 20개), `Next Steps`, `Traps to Avoid` (`(없음)` 기본값, BL-104 적용 전까지), `For Next Session` (에스컬레이션·완료 시점에만).
+
+**6항 규칙(BL-093) 적용 — auto-mode 컨텍스트:**
+
+| # | 규칙 | auto-mode 적용 |
+|---|---|---|
+| 1 | Open Work 상태 서술형 | "X 미구현" (명령형 "X 구현하라" 금지) |
+| 2 | 파일 참조는 라인 번호까지 | code-generation 산출물 인용 시 `path:L<N>-L<M>` |
+| 3 | Traps to Avoid 섹션 | `(없음)` 기본값. BL-104 적용 전까지 auto-fix 폐기는 decision-log에만 |
+| 4 | 검증 지시 포함 | summary 첫 줄에 "이 문서의 주장을 코드/git 상태와 대조해 검증한 후 작업 시작" |
+| 5 | CLAUDE.md 중복 회피 | 첫 줄에 "Read CLAUDE.md first. Do NOT restate" 포함 |
+| 6 | 2K 토큰 상한 (~80-100줄) | 상한 근접 시 Key Decisions / Completed Work 최근 20개 외 삭제 |
 
 ### audit emit 형식
 


### PR DESCRIPTION
Closes #196

## Summary

BL-102 — auto-mode가 Checkpoint에서 session-summary.md를 갱신할 때 BL-093 6항 규칙과 신규 템플릿 필드(Last Updated / Commit / Traps to Avoid / Key Decisions / Next Steps / For Next Session)를 보장하도록 정합 fix.

`session-continuity.md` 메타에 `applies_to: [aidlc-auto-mode, ...]` 명시되어 있으나, 기존 SKILL.md L379는 단순 "템플릿 준수" 한 줄 참조만 있어 자동 진행 모드에서 6항 검증·신규 필드 누락 위험이 있었음.

## Changes

### `skills/aidlc-auto-mode/SKILL.md` (+18/-1)

- Checkpoint 1단계 step 2: "§session-summary 갱신 규칙 준수"로 정밀화
- 신규 `### session-summary 갱신 규칙` 섹션 (C안 — baseline은 `_shared/patterns/session-continuity.md` 참조, auto-mode 특수 규칙만 인라인):
  - 필수 필드 자동 기록 명세 (한 줄 압축)
  - 6항 규칙 auto-mode 컨텍스트 적용 표

### auto-mode 특수 규칙

- `Commit` 필드: Phase 전환·Unit 완료 시점에 갱신
- `Traps to Avoid`: `(없음)` 기본값 (auto-fix 폐기 시도 자동 회수는 BL-104에서)
- `For Next Session`: 자동 진행 중에는 비우고, 에스컬레이션·완료 시점에만 채움
- `Key Decisions / Completed Work`: 2K 상한 근접 시 최근 20개 외 삭제

## Test plan

- [x] `bash skills/aidlc-auto-mode/verify.sh` 통과 (0 errors, 543 lines)
- [ ] auto-mode 자동 진행 시나리오에서 session-summary.md가 6항 + 신규 템플릿 필드 정합 출력 확인
- [ ] mid-cycle pause/resume 시 `For Next Session` 채움 시점 동작 확인

## 관련

- 베이스: `_shared/patterns/session-continuity.md` (BL-093, BL-094, BL-095 통합)
- 후속: BL-103 (#197) Session Resume Handoff=Hypothesis, BL-104 (#198) Traps 자동 회수

🤖 Generated with [Claude Code](https://claude.com/claude-code)