### PR TITLE
fix(auto-mode): Session Resume Handoff=Hypothesis 검증 절차

### DIFF
--- a/skills/aidlc-auto-mode/SKILL.md
+++ b/skills/aidlc-auto-mode/SKILL.md
@@ -409,7 +409,8 @@ plugin 공통 emit 표준(BL-098, memory-sync 패턴) 준수. 상세는 `decisio
 |---|---|---|
 | `auto-mode-invoked` | skill 진입 직후 (Step 1 후) | `mode=new\|resume`, `intent` |
 | `auto-mode-stage-completed` | 매 스테이지 Checkpoint | `stage`, `complexity`, `auto-approved=true` |
-| `auto-mode-resume-drift-detected` | Session Resume drift 감지 시 | `gap` |
+| `auto-mode-resume-drift-detected` | Session Resume Step 3 drift 감지 시 | `gap` |
+| `auto-mode-resume-handoff-verified` | Session Resume Step 4 완료 시 | `completed_work_match`, `traps_count`, `rephrased_count` |
 | `auto-mode-escalated` | 서킷 브레이커 도달/에스컬레이션 | `phase`, `reason`, `retries` |
 
 emit 절차: Read → Edit append (Write 전체 재작성 금지).
@@ -534,10 +535,11 @@ On Activation Step 1에서 재개 선택(A) 시 실행:
      C) 단계별 모드로 전환 (수동 정리)
      ```
    - `auto-mode-invoked` audit emit 시 `mode=resume`, drift 발견 시 `auto-mode-resume-drift-detected | gap=<short>` 추가 emit.
-4. **in-progress 교차 검증**: Current Stage에 `(in-progress)` 포함 시:
+4. **Handoff Verification (Handoff = Hypothesis, BL-095 Phase 1)**: session-summary.md를 fact가 아닌 hypothesis로 다룬다. 4a Completed Work 검증 / 4b Open Work 재해석 / 4c Traps 존중 — 절차/게이트/audit emit 상세는 `session-resume-protocol.md` §Handoff Verification 참조.
+5. **in-progress 교차 검증**: Current Stage에 `(in-progress)` 포함 시:
    - 산출물 파일 존재 → 완료 처리 (Checkpoint 실행), 다음 스테이지로.
    - 산출물 미존재 → 해당 스테이지 처음부터 재실행.
-5. Phase에 따라 해당 플로우 진입:
+6. Phase에 따라 해당 플로우 진입:
    - `INCEPTION` → Phase 1의 해당 스테이지부터 재개.
    - `CONSTRUCTION` → Phase 2의 해당 스테이지부터 재개.
-6. decision-log에 `"session-resumed at [stage]"` 기록.
+7. decision-log에 `"session-resumed at [stage]"` 기록.

--- a/skills/aidlc-auto-mode/session-resume-protocol.md
+++ b/skills/aidlc-auto-mode/session-resume-protocol.md
@@ -1,0 +1,75 @@
+# Session Resume Protocol — auto-mode
+
+auto-mode `## Session Resume` 섹션의 보조 명세. baseline은 `_shared/patterns/session-continuity.md` (Handoff = Hypothesis Phase 1 사용자 가이드, BL-095). 본 문서는 auto-mode 특수 처리만 정의한다.
+
+## Handoff Verification (Step 4)
+
+session-summary.md를 fact가 아닌 hypothesis로 다룬다. 새 세션이 로드 직후 다음 3단계를 실행한다.
+
+### 4a. Completed Work 검증
+
+`## Completed Work`의 각 `[x]` 항목에 대해:
+- 산출물 디렉토리 확인:
+  - INCEPTION 항목 → `devflow-docs/inception/<artifact>.md` 존재
+  - CONSTRUCTION unit 항목 → `devflow-docs/construction/<unit>/code-plan.md` 또는 코드 산출물 존재
+- `git log --oneline -20`에서 stage/unit 키워드 commit 확인
+- 불일치 발견 시 사용자 보고:
+
+```
+⚠️ session-summary 검증 실패
+
+기록: [x] [stage/unit name] — [한 줄 결과]
+실제: [산출물 미존재 | git log 흔적 없음 | ...]
+
+A) 산출물 우선 — summary 갱신 후 재개
+B) summary 우선 — 산출물 재생성 후 재개
+C) 단계별 모드 전환 (수동 정리)
+```
+
+### 4b. Open Work 재해석
+
+명령형 표현 자동 변환 (auto-mode 자동 진행 모드라 사용자 확인 게이트 없이 진행):
+
+| 명령형 (위반) | 상태 서술형 (정합) |
+|---|---|
+| "X를 구현하라" | "X는 미구현" |
+| "Y를 수정하라" | "Y는 수정 필요 상태" |
+| "Z를 호출하라" | "Z 호출 미완" |
+
+변환 결과를 session-summary.md에 갱신하고 decision-log에 `"open-work-rephrased: <원문> → <변환>"` 기록.
+
+### 4c. Traps 존중
+
+`## Traps to Avoid` 항목과 다음 자동 결정의 잠재적 충돌 검사. 다음 중 하나라도 해당하면 미니 게이트:
+- Trap 항목의 키워드(예: "JWT cookie", "websocket polling")가 자동 결정 후보에 포함
+- Trap 항목과 동일한 외부 라이브러리/패턴 재선택
+
+```
+⚠️ Traps to Avoid 충돌 가능성
+
+이전에 폐기한 접근: [Trap 항목 1줄]
+현재 자동 결정: [결정 내용 1줄]
+
+A) Trap 존중 — 다른 접근으로 자동 재선택
+B) 사용자 명시 승인 후 재시도 (Trap 항목에 "재시도 승인 [date]" 코멘트 추가)
+C) 단계별 모드 전환
+```
+
+키워드 매칭 false positive 가능성 — 사용자 게이트가 최종 안전망 역할.
+
+## Audit Emit
+
+Step 4 완료 시 `devflow-docs/audit.md`에 한 줄 append:
+
+```
+[<ISO timestamp>] auto-mode-resume-handoff-verified | completed_work_match=<true|false> | traps_count=<N> | rephrased_count=<N>
+```
+
+drift 감지(Step 3, SKILL.md 본체 참조)와 별개의 emit. drift는 state.md 정합, handoff verification은 session-summary 정합.
+
+## 실패 처리
+
+- 4a 사용자 게이트에서 C 선택 → using-devflow로 전환 (devflow-state는 그대로 유지)
+- 4c 사용자 게이트에서 C 선택 → 동일
+- 4b는 사용자 게이트 없음 (자동 변환만)
+- 모든 단계 PASS → Session Resume Step 5로 진행


### PR DESCRIPTION
Closes #197

## Summary

BL-103 — auto-mode Session Resume에 Handoff = Hypothesis 검증 절차(BL-095 Phase 1)를 추가. session-summary.md를 fact가 아닌 hypothesis로 다루는 3단계 검증(Completed Work / Open Work / Traps).

## 외부 분리 패턴 적용 (BL-105 사전 적용)

매번 한도 상향하는 안티패턴(memory `feedback_systemization_limit.md`)을 차단하기 위해, BL-103 절차를 SKILL.md 인라인 대신 **외부 파일 신설** 패턴으로 처리:

- 신규 `skills/aidlc-auto-mode/session-resume-protocol.md` (75 lines) — 4a/4b/4c 상세 + audit emit + 실패 처리
- SKILL.md Session Resume Step 4는 2-3줄 참조만
- 결과: SKILL.md 545/550 (한도 내, 추가 상향 없음)

기존 인라인 콘텐츠(6항 표 / drift 게이트 / audit emit 표)도 동일 패턴으로 외부 분리 → BL-105 (#201) 별 PR.

## Changes

### `skills/aidlc-auto-mode/session-resume-protocol.md` (신규, 75 lines)

baseline은 `_shared/patterns/session-continuity.md` §사용자 가이드 (Phase 1, BL-095). auto-mode 특수 처리만 정의:
- **4a Completed Work 검증**: 산출물 디렉토리 + git log ↔ summary `[x]` 항목 대조. 불일치 시 3-way 사용자 게이트 (산출물 우선 / summary 우선 / 단계별 모드)
- **4b Open Work 재해석**: 명령형 → 상태 서술형 자동 변환 (auto-mode 자동 진행 모드라 사용자 게이트 없음, decision-log에 변환 기록)
- **4c Traps 존중**: Trap 키워드 ↔ 자동 결정 충돌 검사. 충돌 시 3-way 미니 게이트
- 신규 audit emit: `auto-mode-resume-handoff-verified | completed_work_match=<bool> | traps_count=<N> | rephrased_count=<N>`

### `skills/aidlc-auto-mode/SKILL.md` (+6/-4)

- audit emit 표에 `auto-mode-resume-handoff-verified` prefix 추가
- Session Resume Step 4 신설 (외부 파일 참조만)
- Step 번호 4-6 → 5-7 갱신

## Test plan

- [x] `bash skills/aidlc-auto-mode/verify.sh` 통과 (0 errors, 545 lines)
- [ ] auto-mode 세션 재개 시나리오에서 Step 4 동작 확인 (Completed Work 불일치 게이트 트리거 / Open Work 자동 변환 / Traps 충돌 게이트)
- [ ] audit emit 신규 prefix 일관성 확인 (memory-sync, systematic-debugging 패턴 대조)

## 후속

- BL-105 (#201): 기존 인라인 콘텐츠도 동일 패턴으로 외부 분리 → SKILL.md 한도 500 복귀
- BL-104 (#198): auto-fix 폐기 시도 → Traps 자동 회수 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)