### PR TITLE
fix(reviewers): Calibration 섹션 + max iter 5→3 가드

### DIFF
--- a/devflow-docs/backlog.md
+++ b/devflow-docs/backlog.md
@@ -18,8 +18,6 @@
 - **BL-106**: auto-mode skill-reviewer + Codex adversarial 통합 HIGH 5건 fix — skill-reviewer 2건(6항 #2/#3 + Resume 게이트 모순) + Codex 3건(자기완결성 주석 / verify.sh 외부분리 검증 / 참조 깊이 1단계) [P2] [#204](https://github.com/bluejayA/aidlc-devflow/issues/204)
 - **BL-107**: auto-mode 한도 정책 재검토 — BL-106에서 한도 520 sustainable 자리 약함 입증 (여유 0). 추가 외부 분리 vs 한도 미세 상향 vs orchestrator-only 전환 검토 [P2] [#206](https://github.com/bluejayA/aidlc-devflow/issues/206)
 - **BL-108**: superpowers v5.0.6 — Inline Self-Review 시범 도입 (실험). spec/plan reviewer 1건 self-review 대체 + 비교 [P2] [#207](https://github.com/bluejayA/aidlc-devflow/issues/207)
-- **BL-110**: superpowers v5.1.0 — aidlc named reviewer agent 단일 출처 통합 조사 (drift 차단) [P2] [#209](https://github.com/bluejayA/aidlc-devflow/issues/209)
-- **BL-111**: superpowers v5.0.4 — reviewer 프롬프트 Calibration 섹션 + max iter 3 가드 (skill-forge) [P2] [#210](https://github.com/bluejayA/aidlc-devflow/issues/210)
 - **BL-086**: aidlc-writing-plans에 mapping/매핑 검증 단계 추가 — Task 4 사고 재발 방지 [P2] [#155](https://github.com/bluejayA/aidlc-devflow/issues/155)
 - **BL-088**: MSA 통합 audit 지원 — marker file / config-based scope discovery [P3] [#158](https://github.com/bluejayA/aidlc-devflow/issues/158) (Phase 2 후보; DEVFLOW_ROOT opt-in으로 MVP 대체)
 - **BL-081**: 스킬 라이프사이클 관리 — skill_nature 태깅 + 경량화 체계 도입 [P2] [#145](https://github.com/bluejayA/aidlc-devflow/issues/145) (Phase 1 MVP 1,2번은 BL-085에 흡수, 3,4번 잔존)

--- a/skills/_shared/devflow-conventions.md
+++ b/skills/_shared/devflow-conventions.md
@@ -113,9 +113,9 @@ Codex CLI 설치 시(`command -v codex`) Claude 리뷰 결과에 Codex 실행 �
 1. `_shared/reviewers/[type]-prompt.md` 읽기
 2. 서브에이전트 dispatch (산출물 경로 전달)
 3. ✅ Approved → Return to Orchestrator
-4. ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
+4. ❌ Issues Found → 수정 후 re-dispatch (최대 3회)
 5. Recommendations만 있음 (Issues 없음) → 루프 종료 (수정은 권장)
-6. 5회 초과 시 사용자 escalate
+6. 3회 초과 시 사용자 escalate
 
 ### 리뷰어 프롬프트
 - `_shared/reviewers/spec-document-reviewer-prompt.md` — 설계 문서 (brainstorming)
@@ -130,7 +130,7 @@ Codex CLI 설치 시(`command -v codex`) Claude 리뷰 결과에 Codex 실행 �
 
 ### Escalation 메시지 형식
 ```
-⚠️ 리뷰 루프 5회 초과 — 사용자 판단 필요
+⚠️ 리뷰 루프 3회 초과 — 사용자 판단 필요
 
 리뷰 이력:
 - 1회: [이슈 요약]

--- a/skills/_shared/patterns/review-gate-pattern.md
+++ b/skills/_shared/patterns/review-gate-pattern.md
@@ -30,8 +30,8 @@ last_validated: 2026-04-13
 
 ## 리뷰 루프 제한
 
-- 최대 5회 re-dispatch (conventions 리뷰 루프 규약 참조)
-- 5회 초과 시 conventions escalation 메시지 표시
+- 최대 3회 re-dispatch (conventions 리뷰 루프 규약 참조)
+- 3회 초과 시 conventions escalation 메시지 표시
 
 ## 오버라이드 audit 형식
 

--- a/skills/_shared/reviewers/plan-document-reviewer-prompt.md
+++ b/skills/_shared/reviewers/plan-document-reviewer-prompt.md
@@ -44,6 +44,15 @@ Agent tool (general-purpose type):
     - Missing verification steps or expected outputs
     - Files planned to hold multiple responsibilities or likely to grow unwieldy
 
+    ## Calibration
+
+    승인 차단 기준을 정확히 잡는다. **실제 구현에 문제를 일으킬 이슈만 ❌로 분류한다.**
+
+    - ❌ Issues Found (block): TODO/placeholder, "similar to X" 식 미완 정의, 누락된 검증 단계, spec 미충족, scope creep, 파일 책임 모호
+    - Recommendations (advisory): minor wording, 체크박스 syntax 누락, chunk size 약간 초과, 표현 개선 제안
+
+    의심스러우면 Recommendations로 분류. 승인 차단은 비싼 결정 — 실제 잘못 구현될 위험이 있을 때만.
+
     ## Output Format
 
     ## Plan Review - Chunk N

--- a/skills/_shared/reviewers/spec-document-reviewer-prompt.md
+++ b/skills/_shared/reviewers/spec-document-reviewer-prompt.md
@@ -42,6 +42,15 @@ Agent tool (general-purpose):
     - Sections noticeably less detailed than others
     - Units that lack clear boundaries or interfaces
 
+    ## Calibration
+
+    승인 차단 기준을 정확히 잡는다. **실제 구현에 문제를 일으킬 이슈만 ❌로 분류한다.**
+
+    - ❌ Issues Found (block): 누락된 핵심 요구사항, 모순, 모호한 인터페이스, TODO/placeholder, scope 누락
+    - Recommendations (advisory): minor wording, stylistic preferences, formatting quibbles, 표현 개선 제안
+
+    의심스러우면 Recommendations로 분류. 승인 차단은 비싼 결정 — 실제 잘못 만들어질 위험이 있을 때만.
+
     ## Output Format
 
     ## Spec Review

--- a/skills/aidlc-brainstorming/SKILL.md
+++ b/skills/aidlc-brainstorming/SKILL.md
@@ -92,9 +92,9 @@ metadata:
 
 1. **Minimal / Standard / Comprehensive depth**:
    - `_shared/reviewers/spec-document-reviewer-prompt.md`를 서브에이전트로 dispatch
-   - ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
+   - ❌ Issues Found → 수정 후 re-dispatch (최대 3회)
    - Recommendations만 → 루프 종료 (수정 권장)
-   - 5회 초과 → 사용자 escalate
+   - 3회 초과 → 사용자 escalate
 
 **사용자 리뷰 게이트** (리뷰 통과 후):
 

--- a/skills/aidlc-requesting-code-review/SKILL.md
+++ b/skills/aidlc-requesting-code-review/SKILL.md
@@ -91,7 +91,7 @@ spec/plan 경로가 제공된 경우에만 실행. 미제공 시 Stage 2로 바�
 2. 서브에이전트 dispatch — `{project-root}` + 리뷰 대상 + spec/plan 경로 전달
 3. 결과 확인 (Verdict 기준):
    - PASS → Stage 2로
-   - FAIL → 수정 후 re-dispatch (conventions 리뷰 루프 규약: 최대 5회, 초과 시 사용자 escalate)
+   - FAIL → 수정 후 re-dispatch (conventions 리뷰 루프 규약: 최대 3회, 초과 시 사용자 escalate)
    - CONDITIONAL → Stage 2로 (수정 권장)
 
 #### Codex 세컨드 오피니언 (결과 반환 시 안내)
@@ -138,7 +138,7 @@ Stage 1 완료 후, depth에 따라 병렬 dispatch한다.
 3. `_shared/reviewers/maintainability-reviewer-prompt.md` — Stage 4 서브에이전트 dispatch (background, Comprehensive만)
 4. 모든 결과 수신 후 종합:
    - 모두 PASS → 결과 반환
-   - 일부 FAIL → FAIL stage만 수정 루프 (PASS stage 결과 유지, 최대 5회)
+   - 일부 FAIL → FAIL stage만 수정 루프 (PASS stage 결과 유지, 최대 3회)
    - 모두 FAIL → 모든 stage 수정 루프
 
 ---
@@ -281,7 +281,7 @@ SDD: 태스크 3 완료, requesting-code-review 호출
 
 ### Stage 1에서 반복 실패
 
-**증상**: spec compliance 리뷰가 5회 넘게 실패
+**증상**: spec compliance 리뷰가 3회 넘게 실패
 **원인**: spec 자체가 모호하거나 현재 구현과 맞지 않음
 **해결**: 사용자 escalate 후 spec 수정 또는 Stage 1 스킵 결정
 

--- a/skills/aidlc-writing-plans/SKILL.md
+++ b/skills/aidlc-writing-plans/SKILL.md
@@ -109,9 +109,9 @@ Expected: PASS
 1. **Minimal / Standard / Comprehensive depth**:
    - 청크 작성 완료
    - `_shared/reviewers/plan-document-reviewer-prompt.md`를 서브에이전트로 dispatch
-   - ❌ Issues Found → 수정 후 re-dispatch (최대 5회)
+   - ❌ Issues Found → 수정 후 re-dispatch (최대 3회)
    - Recommendations만 → 루프 종료 (수정 권장)
-   - 5회 초과 → 사용자 escalate
+   - 3회 초과 → 사용자 escalate
 2. 승인 → 다음 청크 또는 Execution Handoff
 
 ## Execution Handoff


### PR DESCRIPTION
Closes #210

## Summary
- superpowers v5.0.4 패턴 적용 — minor/stylistic 이슈가 승인 차단하는 패턴 차단
- max review iterations 5 → 3 (8곳 일괄)
- BL-110(머지됨) + BL-111(이 PR로 closes) backlog cleanup 동봉

## Changes

### Calibration 섹션 추가 (superpowers v5.0.4 명시 대상)
- `_shared/reviewers/spec-document-reviewer-prompt.md` (brainstorming 산출물)
- `_shared/reviewers/plan-document-reviewer-prompt.md` (writing-plans 산출물)

> "실제 구현에 문제를 일으킬 이슈만 ❌로 분류. 의심스러우면 Recommendations로."

### max iter 5 → 3 (8곳)
- `aidlc-brainstorming/SKILL.md` (Spec Review Loop)
- `aidlc-writing-plans/SKILL.md` (Plan Review Loop)
- `aidlc-requesting-code-review/SKILL.md` (Stage 1 + 일부 FAIL 루프 + Troubleshooting)
- `_shared/devflow-conventions.md` (리뷰 루프 규약 + Escalation 메시지)
- `_shared/patterns/review-gate-pattern.md` (리뷰 루프 제한)

### Backlog cleanup
- BL-110 라인 (PR #212로 머지됨)
- BL-111 라인 (이 PR로 closes)

## 페인포인트 정합성
- 4/29 auto-mode SKILL.md 23회 edit (yak shaving) 사례 — reviewer minor fix 반복 패턴
- `memory/feedback_skill_md_external_separation.md` + `feedback_systemization_limit.md` 룰과 동일 방향
- BL-108 (Self-Review 시범) baseline 개선 효과 — self-review vs calibrated reviewer 비교 공정

## Test plan
- [x] pytest **276 passed**
- [x] `verify-change-{1..6}.sh` + `verify-hook-behavioral.sh` 전부 PASS
- [x] `grep -rE "5회|최대 5" skills/ | grep reviewer-related` → 0건
- [ ] 머지 후 BL-111 (#210) close 확인 (`closes #210` 자동)

## 참조
- 분석: `devflow-docs/tracking/session-2026-05-13.md` §2 A4
- BL-111 본문 정정 (#210): "skill-forge plugin 측 변경" → "aidlc 본체 reviewer"

🤖 Generated with [Claude Code](https://claude.com/claude-code)